### PR TITLE
Current locale behaviors

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,16 +1,52 @@
 import { redirect } from 'next/navigation';
-import { headers } from 'next/headers';
+import { cookies, headers } from 'next/headers';
+
+// Supported locales - should match middleware configuration
+const SUPPORTED_LOCALES = ['en', 'zh-HK'] as const;
+const DEFAULT_LOCALE = 'en';
+const LOCALE_COOKIE_NAME = 'NEXT_LOCALE';
+
+/**
+ * Determines the best locale for the user based on:
+ * 1. Stored preference (NEXT_LOCALE cookie) - highest priority
+ * 2. Browser language (Accept-Language header) - fallback for first-time visitors
+ * 3. Default locale (en) - final fallback
+ */
+function detectLocale(
+  storedLocale: string | undefined,
+  acceptLanguage: string
+): string {
+  // Priority 1: Check for stored user preference
+  if (
+    storedLocale &&
+    SUPPORTED_LOCALES.includes(
+      storedLocale as (typeof SUPPORTED_LOCALES)[number]
+    )
+  ) {
+    return storedLocale;
+  }
+
+  // Priority 2: Detect from browser's Accept-Language header
+  // Check for Chinese language preference (zh, zh-HK, zh-TW, zh-CN, etc.)
+  if (acceptLanguage.includes('zh')) {
+    return 'zh-HK';
+  }
+
+  // Priority 3: Default to English
+  return DEFAULT_LOCALE;
+}
 
 export default async function Home() {
-  // Get the Accept-Language header to detect preferred locale
+  // Get stored locale preference from cookie
+  const cookieStore = await cookies();
+  const storedLocale = cookieStore.get(LOCALE_COOKIE_NAME)?.value;
+
+  // Get the Accept-Language header for first-time visitor detection
   const headersList = await headers();
   const acceptLanguage = headersList.get('accept-language') || '';
 
-  // Default to English, but prefer Chinese if available
-  let locale = 'en';
-  if (acceptLanguage.includes('zh') || acceptLanguage.includes('zh-HK')) {
-    locale = 'zh-HK';
-  }
+  // Determine the best locale for this user
+  const locale = detectLocale(storedLocale, acceptLanguage);
 
   redirect(`/${locale}/dashboard`);
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,18 +1,22 @@
 import createMiddleware from 'next-intl/middleware';
+import { defineRouting } from 'next-intl/routing';
 
-export default createMiddleware({
+// Define routing configuration for reuse
+export const routing = defineRouting({
   // Supported locales
   locales: ['en', 'zh-HK'],
 
   // Default locale
   defaultLocale: 'en',
 
-  // Locale detection strategy
-  localeDetection: true,
-
   // Locale prefix strategy - use 'always' for more reliable locale handling
   localePrefix: 'always',
+
+  // Enable locale detection from Accept-Language header for first-time visitors
+  localeDetection: true,
 });
+
+export default createMiddleware(routing);
 
 export const config = {
   // Match all pathnames except for


### PR DESCRIPTION
Implement locale detection for first-time visitors and persist user's locale preference using cookies.

The system now prioritizes a stored `NEXT_LOCALE` cookie for returning users, falls back to the browser's `Accept-Language` header for new visitors, and defaults to English if no preference is found. Manual language switches now set this cookie and trigger a `router.refresh()` for a smoother experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-e56cfe28-e4b1-4dc5-890f-61fb67cf3142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e56cfe28-e4b1-4dc5-890f-61fb67cf3142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements robust i18n locale handling with cookie persistence and consistent routing.
> 
> - Adds `detectLocale` in `app/page.tsx` prioritizing `NEXT_LOCALE` cookie, then `Accept-Language`, then default `en`, and redirects to `/{locale}/dashboard`
> - Updates `LanguageSwitcher` to set `NEXT_LOCALE` cookie, navigate to locale-prefixed paths, and `router.refresh()` for instant translation updates
> - Refactors `middleware.ts` to use `defineRouting` with `locales`, `defaultLocale`, `localePrefix: 'always'`, and `localeDetection: true`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15cc5013cf497bc4934073659eea0f0e125f9990. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->