### PR TITLE
refactor: move queue recommendation logic to api

### DIFF
--- a/app/[locale]/dashboard/page.tsx
+++ b/app/[locale]/dashboard/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { AlertCircle, Clock, RefreshCw } from 'lucide-react';
 
@@ -8,7 +8,7 @@ import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
-import { QueueApiResponse, QueueItem } from '@/lib/types';
+import { QueueApiResponse, QueueGroups, QueueItem } from '@/lib/types';
 import { cn } from '@/lib/utils';
 
 const AUTO_REFRESH_INTERVAL_MS = 30000;
@@ -176,9 +176,20 @@ function QueueListSkeleton({ emphasized = false }: { emphasized?: boolean }) {
   );
 }
 
+function createEmptyGroups(): QueueGroups {
+  return {
+    available: [],
+    low: [],
+    busy: [],
+    unavailable: [],
+  };
+}
+
 export default function DashboardPage() {
   const t = useTranslations('dashboardQueue');
   const [queues, setQueues] = useState<QueueItem[]>([]);
+  const [recommendedQueues, setRecommendedQueues] = useState<QueueItem[]>([]);
+  const [queueGroups, setQueueGroups] = useState<QueueGroups>(createEmptyGroups);
   const [updatedAt, setUpdatedAt] = useState<Date | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -211,6 +222,8 @@ export default function DashboardPage() {
 
       const payload = (await response.json()) as QueueApiResponse;
       setQueues(payload.data);
+      setRecommendedQueues(payload.recommended);
+      setQueueGroups(payload.groups);
       hasDataRef.current = payload.data.length > 0;
       setUpdatedAt(payload.updatedAt ? new Date(payload.updatedAt) : null);
     } catch (error) {
@@ -235,80 +248,22 @@ export default function DashboardPage() {
     return () => clearInterval(interval);
   }, [fetchQueues]);
 
-  const {
-    availableQueues,
-    lowQueues,
-    busyQueues,
-    unavailableQueues,
-    recommendableQueues,
-  } = useMemo(() => {
-    const available: QueueItem[] = [];
-    const low: QueueItem[] = [];
-    const busy: QueueItem[] = [];
-    const unavailable: QueueItem[] = [];
-    const recommendable: QueueItem[] = [];
-
-    queues.forEach((queue) => {
-      if (
-        queue.recommendationState === 'IMMEDIATE' ||
-        queue.recommendationState === 'WAITING'
-      ) {
-        recommendable.push(queue);
-      }
-
-      if (queue.queueCount === null) {
-        unavailable.push(queue);
-      } else if (queue.queueCount === 0) {
-        available.push(queue);
-      } else if (queue.queueCount <= 15) {
-        low.push(queue);
-      } else {
-        busy.push(queue);
-      }
-    });
-
-    return {
-      availableQueues: available,
-      lowQueues: low,
-      busyQueues: busy,
-      unavailableQueues: unavailable,
-      recommendableQueues: recommendable,
-    };
-  }, [queues]);
-
-  const recommendedQueues = useMemo(() => {
-    const immediateQueues = recommendableQueues.filter(
-      (queue) => queue.recommendationState === 'IMMEDIATE'
-    );
-    const waitingQueues = recommendableQueues.filter(
-      (queue) => queue.recommendationState === 'WAITING'
-    );
-    const recommended = immediateQueues.slice(0, 3);
-
-    if (recommended.length < 3) {
-      recommended.push(...waitingQueues.slice(0, 3 - recommended.length));
-    }
-
-    return recommended;
-  }, [recommendableQueues]);
-
-  const recommendedImmediateCount = useMemo(
-    () =>
-      recommendedQueues.filter(
-        (queue) => queue.recommendationState === 'IMMEDIATE'
-      ).length,
-    [recommendedQueues]
-  );
-
+  const eligibleCount =
+    queueGroups.available.length +
+    queueGroups.low.length +
+    queueGroups.busy.length;
+  const recommendedImmediateCount = recommendedQueues.filter(
+    (queue) => queue.queueCount === 0
+  ).length;
   const additionalImmediateCount = Math.max(
     0,
-    availableQueues.length - recommendedImmediateCount
+    queueGroups.available.length - recommendedImmediateCount
   );
   const hasImmediateRecommendations = recommendedImmediateCount > 0;
   const hasRecommendedQueues = recommendedQueues.length > 0;
   const recommendationCountLabel =
-    recommendableQueues.length > 0
-      ? `${recommendedQueues.length}/${recommendableQueues.length}`
+    eligibleCount > 0
+      ? `${recommendedQueues.length}/${eligibleCount}`
       : '0';
 
   const showBlockingError =
@@ -474,30 +429,30 @@ export default function DashboardPage() {
               <>
                 <QueueGroup
                   title={t('availableGroup')}
-                  count={availableQueues.length}
-                  items={availableQueues}
+                  count={queueGroups.available.length}
+                  items={queueGroups.available}
                   emptyText={t('emptyGroup')}
                   getStatusText={getStatusText}
                 />
                 <QueueGroup
                   title={t('lowGroup')}
-                  count={lowQueues.length}
-                  items={lowQueues}
+                  count={queueGroups.low.length}
+                  items={queueGroups.low}
                   emptyText={t('emptyGroup')}
                   getStatusText={getStatusText}
                 />
                 <QueueGroup
                   title={t('busyGroup')}
-                  count={busyQueues.length}
-                  items={busyQueues}
+                  count={queueGroups.busy.length}
+                  items={queueGroups.busy}
                   emptyText={t('emptyGroup')}
                   getStatusText={getStatusText}
                 />
-                {unavailableQueues.length > 0 && (
+                {queueGroups.unavailable.length > 0 && (
                   <QueueGroup
                     title={t('unavailableGroup')}
-                    count={unavailableQueues.length}
-                    items={unavailableQueues}
+                    count={queueGroups.unavailable.length}
+                    items={queueGroups.unavailable}
                     emptyText={t('emptyGroup')}
                     getStatusText={getStatusText}
                   />

--- a/app/api/queues/route.ts
+++ b/app/api/queues/route.ts
@@ -1,63 +1,13 @@
 import { NextResponse } from 'next/server';
 
 import { fetchLiveStores } from '@/lib/live-stores';
-import { QueueApiResponse, QueueItem } from '@/lib/types';
-import { getQueuePriority } from '@/lib/utils';
-
-function isRecommendableStatus(storeStatus: string): boolean {
-  return storeStatus === 'OPEN' || storeStatus === 'BUSY';
-}
-
-function normalizeQueueCount(value: unknown): number | null {
-  return typeof value === 'number' && Number.isFinite(value) && value >= 0
-    ? value
-    : null;
-}
-
-function getSortableQueueCount(queueCount: number | null): number {
-  return queueCount ?? Number.POSITIVE_INFINITY;
-}
-
-function compareQueueItems(left: QueueItem, right: QueueItem): number {
-  const leftCount = getSortableQueueCount(left.queueCount);
-  const rightCount = getSortableQueueCount(right.queueCount);
-
-  if (leftCount < rightCount) {
-    return -1;
-  }
-
-  if (leftCount > rightCount) {
-    return 1;
-  }
-
-  return left.name.localeCompare(right.name, 'zh-HK');
-}
-
-function buildQueueItem(
-  name: string,
-  storeStatus: string,
-  rawQueueCount: unknown
-): QueueItem {
-  const normalizedQueueCount = normalizeQueueCount(rawQueueCount);
-  const queueCount = isRecommendableStatus(storeStatus)
-    ? normalizedQueueCount
-    : null;
-  const recommendationState = !isRecommendableStatus(storeStatus)
-    ? 'INELIGIBLE'
-    : queueCount === null
-      ? 'UNAVAILABLE'
-      : queueCount === 0
-        ? 'IMMEDIATE'
-        : 'WAITING';
-
-  return {
-    name,
-    storeStatus,
-    queueCount,
-    level: getQueuePriority(queueCount ?? 0),
-    recommendationState,
-  };
-}
+import { buildQueueItem, compareQueueItems } from '@/lib/queue-items';
+import {
+  buildQueueGroups,
+  buildRecommendedQueues,
+  createEmptyQueueGroups,
+} from '@/lib/queue-response';
+import { QueueApiResponse } from '@/lib/types';
 
 export async function GET(): Promise<NextResponse<QueueApiResponse>> {
   try {
@@ -69,10 +19,14 @@ export async function GET(): Promise<NextResponse<QueueApiResponse>> {
         buildQueueItem(store.name, store.storeStatus, store.waitingGroup)
       )
       .sort(compareQueueItems);
+    const groups = buildQueueGroups(data);
+    const recommended = buildRecommendedQueues(groups);
 
     return NextResponse.json({
       updatedAt: updatedAt.toISOString(),
       data,
+      recommended,
+      groups,
     });
   } catch (error) {
     console.error('Error in queues API:', error);
@@ -81,6 +35,8 @@ export async function GET(): Promise<NextResponse<QueueApiResponse>> {
       {
         updatedAt: new Date().toISOString(),
         data: [],
+        recommended: [],
+        groups: createEmptyQueueGroups(),
       },
       { status: 503 }
     );

--- a/lib/queue-items.test.ts
+++ b/lib/queue-items.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildQueueItem,
+  compareQueueItems,
+  getRecommendationState,
+  getSortableQueueCount,
+  isRecommendableStatus,
+  normalizeQueueCount,
+} from '@/lib/queue-items';
+
+describe('queue item helpers', () => {
+  it('normalizes queue counts and recommendable statuses', () => {
+    expect(isRecommendableStatus('OPEN')).toBe(true);
+    expect(isRecommendableStatus('BUSY')).toBe(true);
+    expect(isRecommendableStatus('CLOSED')).toBe(false);
+
+    expect(normalizeQueueCount(0)).toBe(0);
+    expect(normalizeQueueCount(12)).toBe(12);
+    expect(normalizeQueueCount(-1)).toBeNull();
+    expect(normalizeQueueCount(Number.NaN)).toBeNull();
+    expect(normalizeQueueCount('12')).toBeNull();
+  });
+
+  it('derives recommendation state deterministically', () => {
+    expect(getRecommendationState('CLOSED', 0)).toBe('INELIGIBLE');
+    expect(getRecommendationState('OPEN', null)).toBe('UNAVAILABLE');
+    expect(getRecommendationState('OPEN', 0)).toBe('IMMEDIATE');
+    expect(getRecommendationState('BUSY', 10)).toBe('WAITING');
+  });
+
+  it('builds queue items with normalized queue data', () => {
+    expect(buildQueueItem('Mong Kok', 'OPEN', 0)).toEqual({
+      name: 'Mong Kok',
+      storeStatus: 'OPEN',
+      queueCount: 0,
+      level: 'LOW',
+      recommendationState: 'IMMEDIATE',
+    });
+
+    expect(buildQueueItem('Central', 'OPEN', 'unknown')).toEqual({
+      name: 'Central',
+      storeStatus: 'OPEN',
+      queueCount: null,
+      level: 'LOW',
+      recommendationState: 'UNAVAILABLE',
+    });
+
+    expect(buildQueueItem('Sha Tin', 'CLOSED', 5)).toEqual({
+      name: 'Sha Tin',
+      storeStatus: 'CLOSED',
+      queueCount: null,
+      level: 'LOW',
+      recommendationState: 'INELIGIBLE',
+    });
+  });
+
+  it('sorts by queue count first and then by name', () => {
+    const immediate = buildQueueItem('Zeta', 'OPEN', 0);
+    const waiting = buildQueueItem('Alpha', 'OPEN', 2);
+    const unavailableA = buildQueueItem('Beta', 'OPEN', 'unknown');
+    const unavailableB = buildQueueItem('Alpha', 'CLOSED', 0);
+
+    const sorted = [unavailableA, immediate, unavailableB, waiting].sort(
+      compareQueueItems
+    );
+
+    expect(sorted).toEqual([immediate, waiting, unavailableB, unavailableA]);
+    expect(getSortableQueueCount(null)).toBe(Number.POSITIVE_INFINITY);
+  });
+});

--- a/lib/queue-items.ts
+++ b/lib/queue-items.ts
@@ -1,0 +1,68 @@
+import { QueueItem, QueueRecommendationState } from '@/lib/types';
+import { getQueuePriority } from '@/lib/utils';
+
+export function isRecommendableStatus(storeStatus: string): boolean {
+  return storeStatus === 'OPEN' || storeStatus === 'BUSY';
+}
+
+export function normalizeQueueCount(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? value
+    : null;
+}
+
+export function getSortableQueueCount(queueCount: number | null): number {
+  return queueCount ?? Number.POSITIVE_INFINITY;
+}
+
+export function getRecommendationState(
+  storeStatus: string,
+  queueCount: number | null
+): QueueRecommendationState {
+  if (!isRecommendableStatus(storeStatus)) {
+    return 'INELIGIBLE';
+  }
+
+  if (queueCount === null) {
+    return 'UNAVAILABLE';
+  }
+
+  if (queueCount === 0) {
+    return 'IMMEDIATE';
+  }
+
+  return 'WAITING';
+}
+
+export function compareQueueItems(left: QueueItem, right: QueueItem): number {
+  const leftCount = getSortableQueueCount(left.queueCount);
+  const rightCount = getSortableQueueCount(right.queueCount);
+
+  if (leftCount < rightCount) {
+    return -1;
+  }
+
+  if (leftCount > rightCount) {
+    return 1;
+  }
+
+  return left.name.localeCompare(right.name, 'zh-HK');
+}
+
+export function buildQueueItem(
+  name: string,
+  storeStatus: string,
+  rawQueueCount: unknown
+): QueueItem {
+  const queueCount = isRecommendableStatus(storeStatus)
+    ? normalizeQueueCount(rawQueueCount)
+    : null;
+
+  return {
+    name,
+    storeStatus,
+    queueCount,
+    level: getQueuePriority(queueCount ?? 0),
+    recommendationState: getRecommendationState(storeStatus, queueCount),
+  };
+}

--- a/lib/queue-response.test.ts
+++ b/lib/queue-response.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildQueueGroups, buildRecommendedQueues } from '@/lib/queue-response';
+import { QueueItem } from '@/lib/types';
+
+function createQueueItem(
+  name: string,
+  queueCount: number | null,
+  recommendationState: QueueItem['recommendationState'] = 'WAITING',
+  storeStatus = 'OPEN'
+): QueueItem {
+  return {
+    name,
+    storeStatus,
+    queueCount,
+    level: 'LOW',
+    recommendationState,
+  };
+}
+
+describe('queue response helpers', () => {
+  it('classifies items into fixed ordered groups', () => {
+    const available = createQueueItem('Central', 0, 'IMMEDIATE');
+    const low = createQueueItem('Kowloon', 12);
+    const busy = createQueueItem('Tsuen Wan', 24);
+    const unavailable = createQueueItem('Causeway Bay', null, 'UNAVAILABLE');
+
+    const groups = buildQueueGroups([available, low, busy, unavailable]);
+
+    expect(Object.keys(groups)).toEqual([
+      'available',
+      'low',
+      'busy',
+      'unavailable',
+    ]);
+    expect(groups.available[0]).toBe(available);
+    expect(groups.low[0]).toBe(low);
+    expect(groups.busy[0]).toBe(busy);
+    expect(groups.unavailable[0]).toBe(unavailable);
+  });
+
+  it('reuses eligible item references and excludes unavailable items from recommendations', () => {
+    const availableA = createQueueItem('Central', 0, 'IMMEDIATE');
+    const availableB = createQueueItem('Mong Kok', 0, 'IMMEDIATE');
+    const low = createQueueItem('Tsim Sha Tsui', 4);
+    const busy = createQueueItem('Sha Tin', 16);
+    const unavailable = createQueueItem('Tai Po', null, 'UNAVAILABLE');
+
+    const groups = buildQueueGroups([
+      availableA,
+      availableB,
+      low,
+      busy,
+      unavailable,
+    ]);
+    const recommended = buildRecommendedQueues(groups);
+
+    expect(recommended).toHaveLength(3);
+    expect(recommended).toEqual([availableA, availableB, low]);
+    expect(recommended[0]).toBe(availableA);
+    expect(recommended[1]).toBe(availableB);
+    expect(recommended[2]).toBe(low);
+    expect(recommended).not.toContain(unavailable);
+  });
+
+  it('falls back from available to low to busy when building recommendations', () => {
+    const lowA = createQueueItem('Admiralty', 2);
+    const lowB = createQueueItem('Jordan', 8);
+    const busy = createQueueItem('Yuen Long', 20);
+
+    const groups = buildQueueGroups([lowA, lowB, busy]);
+    const recommended = buildRecommendedQueues(groups);
+
+    expect(recommended).toEqual([lowA, lowB, busy]);
+  });
+});

--- a/lib/queue-response.ts
+++ b/lib/queue-response.ts
@@ -1,0 +1,40 @@
+import type { QueueGroupKey, QueueGroups, QueueItem } from './types';
+
+export function getQueueGroup(item: QueueItem): QueueGroupKey {
+  if (item.queueCount === null) {
+    return 'unavailable';
+  }
+
+  if (item.queueCount === 0) {
+    return 'available';
+  }
+
+  if (item.queueCount <= 15) {
+    return 'low';
+  }
+
+  return 'busy';
+}
+
+export function createEmptyQueueGroups(): QueueGroups {
+  return {
+    available: [],
+    low: [],
+    busy: [],
+    unavailable: [],
+  };
+}
+
+export function buildQueueGroups(data: QueueItem[]): QueueGroups {
+  const groups = createEmptyQueueGroups();
+
+  data.forEach((item) => {
+    groups[getQueueGroup(item)].push(item);
+  });
+
+  return groups;
+}
+
+export function buildRecommendedQueues(groups: QueueGroups): QueueItem[] {
+  return [...groups.available, ...groups.low, ...groups.busy].slice(0, 3);
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -159,9 +159,20 @@ export interface QueueItem {
   recommendationState: QueueRecommendationState;
 }
 
+export type QueueGroupKey = 'available' | 'low' | 'busy' | 'unavailable';
+
+export interface QueueGroups {
+  available: QueueItem[];
+  low: QueueItem[];
+  busy: QueueItem[];
+  unavailable: QueueItem[];
+}
+
 export interface QueueApiResponse {
   updatedAt: string;
   data: QueueItem[];
+  recommended: QueueItem[];
+  groups: QueueGroups;
 }
 
 // Dashboard specific types


### PR DESCRIPTION
## Summary
- move queue recommendation and grouping ownership into `/api/queues`
- extend the queue response contract with backend-derived `recommended` and `groups`
- update the dashboard to consume backend-derived queue groups and recommendations without recomputing them in the page

## Contract notes
- `data` remains the canonical flat list of `QueueItem`s
- `groups` are derived from `data` and keep fixed order: `available -> low -> busy -> unavailable`
- `recommended` is derived from eligible grouped items only (`available + low + busy`)
- `recommended` and `groups` reuse the same `QueueItem` object references already present in `data`

## Testing
- npm run test:run
- npm run type-check
- npx tsc -p tsconfig.vitest.json --noEmit
- npm run lint