### PR TITLE
feat: add hierarchical recommendation preferences

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,12 +26,19 @@ Browser
 
 `GET /api/queues` is the primary app contract. Keep it stable.
 
+Public request interface:
+
+- `preferredBranch=<shopId>` accepts an optional positive integer branch id
+- `preferredCluster=<clusterId>` accepts an optional `RecommendationCluster`
+- Query params are the source of truth for recommendation preference input
+- Backend resolution is authoritative: route parsing and snapshot building decide whether the active mode is `branch`, `cluster`, or `auto`
+
 ```ts
 interface QueueApiResponse {
   status: 'success' | 'partial' | 'unavailable';
   updatedAt: string;
   data: QueueItem[];
-  recommended: QueueItem[];
+  recommended: RecommendedQueueItem[];
   groups: QueueGroups;
   warnings: string[];
   partialData: boolean;
@@ -40,6 +47,19 @@ interface QueueApiResponse {
     totalStores: number;
     successfulQueueFetches: number;
     failedQueueFetches: number;
+  };
+  preferences: {
+    requestedBranchShopId?: number;
+    requestedCluster?: RecommendationCluster;
+    activeMode: 'branch' | 'cluster' | 'auto';
+    activeBranchShopId?: number;
+    activeCluster?: RecommendationCluster;
+    fallbackReasonCode?:
+      | 'PREFERRED_BRANCH_NOT_FOUND'
+      | 'PREFERRED_BRANCH_INELIGIBLE'
+      | 'PREFERRED_CLUSTER_UNAVAILABLE';
+    branchOptions: RecommendationBranchOption[];
+    clusterOptions: RecommendationCluster[];
   };
 }
 ```
@@ -51,13 +71,18 @@ Rules:
 - Use `partial` when branch metadata exists but some queue requests fail.
 - Use `unavailable` only when the route cannot produce a usable branch snapshot.
 - Keep route handlers thin and push deterministic logic into `lib/`.
+- Do not make the frontend infer active preference mode from raw query params. Use `response.preferences` as the public backend decision.
 
 ## Recommendation Rules
 
 - Recommendation ranking lives in `lib/queue-recommendations.ts`.
+- Preference parsing and fallback resolution live in `lib/recommendation-preferences.ts`.
 - Queue normalization lives in `lib/queue-items.ts`.
 - Cluster mapping lives in `lib/recommendation-clusters.ts`.
 - Recommendations may render in `partial` mode because ranking uses the normalized branch snapshot, not queue-fetch success alone.
+- Supported precedence is `preferred branch > preferred cluster > auto`.
+- If a preferred branch is invalid or ineligible, fall back to cluster when possible; otherwise fall back to auto.
+- If a preferred cluster has no eligible candidates, fall back to auto and surface that via `preferences.fallbackReasonCode`.
 - If recommendation behavior changes, update tests and docs in the same change.
 
 ## Internationalization

--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ npm run dev
 
 The dashboard consumes `GET /api/queues`.
 
+Public request interface:
+
+- `preferredBranch=<shopId>`: optional positive integer branch preference
+- `preferredCluster=<clusterId>`: optional cluster preference using a valid `RecommendationCluster` value
+- If both are present, the backend resolves precedence as `preferredBranch > preferredCluster > auto`
+- Invalid query-param values are ignored during parsing; the backend still returns explicit resolved `preferences` metadata so the frontend does not guess
+
 The route always returns the same JSON shape:
 
 ```ts
@@ -63,7 +70,7 @@ interface QueueApiResponse {
   status: QueueSnapshotStatus;
   updatedAt: string;
   data: QueueItem[];
-  recommended: QueueItem[];
+  recommended: RecommendedQueueItem[];
   groups: QueueGroups;
   warnings: string[];
   partialData: boolean;
@@ -73,8 +80,32 @@ interface QueueApiResponse {
     successfulQueueFetches: number;
     failedQueueFetches: number;
   };
+  preferences: {
+    requestedBranchShopId?: number;
+    requestedCluster?: RecommendationCluster;
+    activeMode: 'branch' | 'cluster' | 'auto';
+    activeBranchShopId?: number;
+    activeCluster?: RecommendationCluster;
+    fallbackReasonCode?:
+      | 'PREFERRED_BRANCH_NOT_FOUND'
+      | 'PREFERRED_BRANCH_INELIGIBLE'
+      | 'PREFERRED_CLUSTER_UNAVAILABLE';
+    branchOptions: Array<{
+      shopId: number;
+      name: string;
+      cluster: RecommendationCluster;
+    }>;
+    clusterOptions: RecommendationCluster[];
+  };
 }
 ```
+
+`preferences` is part of the public response contract. Treat it as the backend-owned source of truth for:
+
+- which preference inputs were accepted from the URL
+- which recommendation mode is actually active
+- whether the backend fell back from branch to cluster or auto
+- which selector options the frontend should render
 
 Status semantics:
 
@@ -101,12 +132,15 @@ HTTP semantics:
 Recommendations currently:
 
 - include only `IMMEDIATE` and `WAITING` queue items
+- resolve preference precedence backend-side as `preferred branch > preferred cluster > auto`
+- fall back from an invalid or ineligible branch to cluster when possible
+- fall back from an unavailable cluster to auto
 - prefer the best branch inside the anchor cluster
 - fall back to adjacent clusters
 - then fall back to the remaining eligible global pool
 - cap the list at 3 branches
 
-This keeps the recommendations deterministic and testable without needing persistence or personalization.
+This keeps the recommendations deterministic and testable without needing persistence or personalization. The frontend should only sync URL params and render the resolved `preferences` metadata returned by the API.
 
 ## Project Structure
 

--- a/app/[locale]/dashboard/page.tsx
+++ b/app/[locale]/dashboard/page.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { type ChangeEvent, useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Suspense,
+  type ChangeEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { AlertCircle, Clock, RefreshCw } from 'lucide-react';
@@ -247,7 +254,7 @@ function findBranchOption(
   return branchOptions.find((option) => option.shopId === shopId);
 }
 
-export default function DashboardPage() {
+function DashboardPageContent() {
   const t = useTranslations('dashboardQueue');
   const router = useRouter();
   const pathname = usePathname();
@@ -375,23 +382,36 @@ export default function DashboardPage() {
       ? preferenceMeta.activeCluster ?? ''
       : preferenceMeta.requestedCluster ?? '';
 
-  const clusterLabelMap: Record<RecommendationCluster, string> = {
-    HK_ISLAND_WEST: t('preference.clusterLabels.HK_ISLAND_WEST'),
-    HK_ISLAND_EAST: t('preference.clusterLabels.HK_ISLAND_EAST'),
-    WEST_KOWLOON: t('preference.clusterLabels.WEST_KOWLOON'),
-    EAST_KOWLOON: t('preference.clusterLabels.EAST_KOWLOON'),
-    TSEUNG_KWAN_O: t('preference.clusterLabels.TSEUNG_KWAN_O'),
-    SHA_TIN_BELT: t('preference.clusterLabels.SHA_TIN_BELT'),
-    NORTH_NT: t('preference.clusterLabels.NORTH_NT'),
-    TSUEN_KWAN_WEST: t('preference.clusterLabels.TSUEN_KWAN_WEST'),
-    FAR_WEST_NT: t('preference.clusterLabels.FAR_WEST_NT'),
-    UNKNOWN: t('preference.clusterLabels.UNKNOWN'),
-  };
-
   const getClusterLabel = useCallback(
-    (cluster: RecommendationCluster | undefined) =>
-      cluster === undefined ? '' : clusterLabelMap[cluster],
-    [clusterLabelMap]
+    (cluster: RecommendationCluster | undefined) => {
+      if (cluster === undefined) {
+        return '';
+      }
+
+      switch (cluster) {
+        case 'HK_ISLAND_WEST':
+          return t('preference.clusterLabels.HK_ISLAND_WEST');
+        case 'HK_ISLAND_EAST':
+          return t('preference.clusterLabels.HK_ISLAND_EAST');
+        case 'WEST_KOWLOON':
+          return t('preference.clusterLabels.WEST_KOWLOON');
+        case 'EAST_KOWLOON':
+          return t('preference.clusterLabels.EAST_KOWLOON');
+        case 'TSEUNG_KWAN_O':
+          return t('preference.clusterLabels.TSEUNG_KWAN_O');
+        case 'SHA_TIN_BELT':
+          return t('preference.clusterLabels.SHA_TIN_BELT');
+        case 'NORTH_NT':
+          return t('preference.clusterLabels.NORTH_NT');
+        case 'TSUEN_KWAN_WEST':
+          return t('preference.clusterLabels.TSUEN_KWAN_WEST');
+        case 'FAR_WEST_NT':
+          return t('preference.clusterLabels.FAR_WEST_NT');
+        case 'UNKNOWN':
+          return t('preference.clusterLabels.UNKNOWN');
+      }
+    },
+    [t]
   );
 
   const getReasonLabel = useCallback(
@@ -786,5 +806,39 @@ export default function DashboardPage() {
         </>
       )}
     </div>
+  );
+}
+
+function DashboardPageFallback() {
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-5 px-4 pb-10 pt-4 sm:pt-6">
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="h-8 w-64" />
+          <Skeleton className="h-4 w-full max-w-xl" />
+        </div>
+        <div className="grid gap-3 rounded-2xl border border-border bg-card p-4 sm:grid-cols-2">
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-10 w-full" />
+          </div>
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-10 w-full" />
+          </div>
+        </div>
+      </div>
+      <QueueListSkeleton emphasized />
+      <QueueListSkeleton />
+    </div>
+  );
+}
+
+export default function DashboardPage() {
+  return (
+    <Suspense fallback={<DashboardPageFallback />}>
+      <DashboardPageContent />
+    </Suspense>
   );
 }

--- a/app/[locale]/dashboard/page.tsx
+++ b/app/[locale]/dashboard/page.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { AlertCircle, Clock, RefreshCw } from 'lucide-react';
 
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -15,16 +17,27 @@ import {
   QueueItem,
   QueueSnapshotMeta,
   QueueSnapshotStatus,
+  RECOMMENDATION_FALLBACK_REASON_CODES,
+  RECOMMENDATION_MODES,
+  RECOMMENDATION_REASON_CODES,
+  RecommendedQueueItem,
+  RecommendationBranchOption,
+  RecommendationCluster,
+  RecommendationFallbackReasonCode,
+  RecommendationPreferenceMeta,
+  RecommendationReasonCode,
 } from '@/lib/types';
 import { cn } from '@/lib/utils';
 
 const AUTO_REFRESH_INTERVAL_MS = 30000;
 
 interface QueueRowProps {
-  item: QueueItem;
+  item: QueueItem | RecommendedQueueItem;
   statusText: string;
   tone: 'available' | 'low' | 'busy' | 'invalid';
   emphasized?: boolean;
+  reasonCodes?: RecommendationReasonCode[];
+  getReasonLabel?: (reasonCode: RecommendationReasonCode) => string;
 }
 
 interface QueueGroupProps {
@@ -82,6 +95,8 @@ function QueueRow({
   statusText,
   tone,
   emphasized = false,
+  reasonCodes,
+  getReasonLabel,
 }: QueueRowProps) {
   const valueText = getValueText(item);
 
@@ -109,6 +124,19 @@ function QueueRow({
         >
           {statusText}
         </p>
+        {reasonCodes !== undefined && getReasonLabel !== undefined && (
+          <div className="mt-2 flex flex-wrap gap-2">
+            {reasonCodes.map((reasonCode) => (
+              <Badge
+                key={`${item.shopId}-${reasonCode}`}
+                variant={emphasized ? 'outline' : 'secondary'}
+                className="text-[11px]"
+              >
+                {getReasonLabel(reasonCode)}
+              </Badge>
+            ))}
+          </div>
+        )}
       </div>
 
       {valueText !== null && (
@@ -200,15 +228,32 @@ function createEmptyMeta(): QueueSnapshotMeta {
   };
 }
 
+function createEmptyPreferenceMeta(): RecommendationPreferenceMeta {
+  return {
+    activeMode: RECOMMENDATION_MODES.AUTO,
+    branchOptions: [],
+    clusterOptions: [],
+  };
+}
+
 export default function DashboardPage() {
   const t = useTranslations('dashboardQueue');
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const queryString = searchParams.toString();
   const [queues, setQueues] = useState<QueueItem[]>([]);
-  const [recommendedQueues, setRecommendedQueues] = useState<QueueItem[]>([]);
+  const [recommendedQueues, setRecommendedQueues] = useState<
+    RecommendedQueueItem[]
+  >([]);
   const [queueGroups, setQueueGroups] = useState<QueueGroups>(createEmptyGroups);
   const [snapshotStatus, setSnapshotStatus] = useState<QueueSnapshotStatus>(
     QUEUE_SNAPSHOT_STATUS.SUCCESS
   );
   const [meta, setMeta] = useState<QueueSnapshotMeta>(createEmptyMeta);
+  const [preferenceMeta, setPreferenceMeta] = useState<RecommendationPreferenceMeta>(
+    createEmptyPreferenceMeta
+  );
   const [updatedAt, setUpdatedAt] = useState<Date | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -233,7 +278,10 @@ export default function DashboardPage() {
         setIsLoading(true);
       }
 
-      const response = await fetch('/api/queues', { cache: 'no-store' });
+      const response = await fetch(
+        queryString.length > 0 ? `/api/queues?${queryString}` : '/api/queues',
+        { cache: 'no-store' }
+      );
       const payload = (await response.json()) as QueueApiResponse;
 
       setQueues(payload.data);
@@ -241,6 +289,7 @@ export default function DashboardPage() {
       setQueueGroups(payload.groups);
       setSnapshotStatus(payload.status);
       setMeta(payload.meta);
+      setPreferenceMeta(payload.preferences);
       hasDataRef.current = payload.data.length > 0;
       setUpdatedAt(payload.updatedAt ? new Date(payload.updatedAt) : null);
 
@@ -251,13 +300,14 @@ export default function DashboardPage() {
       console.error('Error fetching queues:', error);
       setSnapshotStatus(QUEUE_SNAPSHOT_STATUS.UNAVAILABLE);
       setMeta(createEmptyMeta());
+      setPreferenceMeta(createEmptyPreferenceMeta());
       setErrorMessage(t('error'));
     } finally {
       setIsLoading(false);
       setIsRefreshing(false);
       isFetchingRef.current = false;
     }
-  }, [t]);
+  }, [queryString, t]);
 
   useEffect(() => {
     void fetchQueues();
@@ -299,6 +349,127 @@ export default function DashboardPage() {
     errorMessage !== null &&
     queues.length > 0 &&
     snapshotStatus !== QUEUE_SNAPSHOT_STATUS.PARTIAL;
+
+  const clusterLabelMap: Record<RecommendationCluster, string> = {
+    HK_ISLAND_WEST: t('preference.clusterLabels.HK_ISLAND_WEST'),
+    HK_ISLAND_EAST: t('preference.clusterLabels.HK_ISLAND_EAST'),
+    WEST_KOWLOON: t('preference.clusterLabels.WEST_KOWLOON'),
+    EAST_KOWLOON: t('preference.clusterLabels.EAST_KOWLOON'),
+    TSEUNG_KWAN_O: t('preference.clusterLabels.TSEUNG_KWAN_O'),
+    SHA_TIN_BELT: t('preference.clusterLabels.SHA_TIN_BELT'),
+    NORTH_NT: t('preference.clusterLabels.NORTH_NT'),
+    TSUEN_KWAN_WEST: t('preference.clusterLabels.TSUEN_KWAN_WEST'),
+    FAR_WEST_NT: t('preference.clusterLabels.FAR_WEST_NT'),
+    UNKNOWN: t('preference.clusterLabels.UNKNOWN'),
+  };
+
+  const getClusterLabel = useCallback(
+    (cluster: RecommendationCluster | undefined) =>
+      cluster === undefined ? '' : clusterLabelMap[cluster],
+    [clusterLabelMap]
+  );
+
+  const getReasonLabel = useCallback(
+    (reasonCode: RecommendationReasonCode) => {
+      switch (reasonCode) {
+        case RECOMMENDATION_REASON_CODES.PREFERRED_BRANCH:
+          return t('preference.reasonLabels.PREFERRED_BRANCH');
+        case RECOMMENDATION_REASON_CODES.SAME_CLUSTER_AS_PREFERRED_BRANCH:
+          return t('preference.reasonLabels.SAME_CLUSTER_AS_PREFERRED_BRANCH');
+        case RECOMMENDATION_REASON_CODES.IN_SELECTED_CLUSTER:
+          return t('preference.reasonLabels.IN_SELECTED_CLUSTER');
+        case RECOMMENDATION_REASON_CODES.NEARBY_FALLBACK:
+          return t('preference.reasonLabels.NEARBY_FALLBACK');
+        case RECOMMENDATION_REASON_CODES.BEST_FALLBACK:
+          return t('preference.reasonLabels.BEST_FALLBACK');
+        case RECOMMENDATION_REASON_CODES.OPEN_NOW:
+          return t('preference.reasonLabels.OPEN_NOW');
+        case RECOMMENDATION_REASON_CODES.SHORT_WAIT:
+          return t('preference.reasonLabels.SHORT_WAIT');
+      }
+    },
+    [t]
+  );
+
+  const replacePreferenceParams = useCallback(
+    (updater: (params: URLSearchParams) => void) => {
+      const nextParams = new URLSearchParams(queryString);
+      updater(nextParams);
+      const nextQuery = nextParams.toString();
+
+      router.replace(nextQuery.length > 0 ? `${pathname}?${nextQuery}` : pathname);
+    },
+    [pathname, queryString, router]
+  );
+
+  const handleBranchChange = useCallback(
+    (nextValue: string) => {
+      replacePreferenceParams((params) => {
+        if (nextValue.length === 0) {
+          params.delete('preferredBranch');
+          return;
+        }
+
+        params.set('preferredBranch', nextValue);
+      });
+    },
+    [replacePreferenceParams]
+  );
+
+  const handleClusterChange = useCallback(
+    (nextValue: string) => {
+      replacePreferenceParams((params) => {
+        if (nextValue.length === 0) {
+          params.delete('preferredCluster');
+          return;
+        }
+
+        params.set('preferredCluster', nextValue);
+        const currentBranch = preferenceMeta.branchOptions.find(
+          (option) => option.shopId === preferenceMeta.requestedBranchShopId
+        );
+
+        if (
+          currentBranch !== undefined &&
+          currentBranch.cluster !== nextValue
+        ) {
+          params.delete('preferredBranch');
+        }
+      });
+    },
+    [preferenceMeta.branchOptions, preferenceMeta.requestedBranchShopId, replacePreferenceParams]
+  );
+
+  const activeBranch = preferenceMeta.branchOptions.find(
+    (option) => option.shopId === preferenceMeta.activeBranchShopId
+  );
+
+  const getFallbackMessage = useCallback(
+    (fallbackReasonCode: RecommendationFallbackReasonCode | undefined) => {
+      switch (fallbackReasonCode) {
+        case RECOMMENDATION_FALLBACK_REASON_CODES.PREFERRED_BRANCH_NOT_FOUND:
+          return t('preference.fallbackMessages.PREFERRED_BRANCH_NOT_FOUND');
+        case RECOMMENDATION_FALLBACK_REASON_CODES.PREFERRED_BRANCH_INELIGIBLE:
+          return t('preference.fallbackMessages.PREFERRED_BRANCH_INELIGIBLE');
+        case RECOMMENDATION_FALLBACK_REASON_CODES.PREFERRED_CLUSTER_UNAVAILABLE:
+          return t('preference.fallbackMessages.PREFERRED_CLUSTER_UNAVAILABLE');
+        default:
+          return null;
+      }
+    },
+    [t]
+  );
+
+  const activeModeLabel =
+    preferenceMeta.activeMode === RECOMMENDATION_MODES.BRANCH &&
+    activeBranch !== undefined
+      ? t('preference.activeMode.branch', { name: activeBranch.name })
+      : preferenceMeta.activeMode === RECOMMENDATION_MODES.CLUSTER &&
+          preferenceMeta.activeCluster !== undefined
+        ? t('preference.activeMode.cluster', {
+            cluster: getClusterLabel(preferenceMeta.activeCluster),
+          })
+        : t('preference.activeMode.auto');
 
   const getStatusText = useCallback(
     (item: QueueItem) => {
@@ -376,6 +547,68 @@ export default function DashboardPage() {
           </div>
         </div>
       </div>
+
+      <section className="rounded-2xl border border-border bg-card p-4">
+        <div className="flex flex-col gap-4">
+          <div className="space-y-1">
+            <p className="text-sm font-semibold text-foreground">
+              {t('preference.title')}
+            </p>
+            <p className="text-sm text-muted-foreground">
+              {t('preference.subtitle')}
+            </p>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <label className="space-y-2 text-sm">
+              <span className="font-medium text-foreground">
+                {t('preference.branchLabel')}
+              </span>
+              <select
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground"
+                value={preferenceMeta.requestedBranchShopId?.toString() ?? ''}
+                onChange={(event) => handleBranchChange(event.target.value)}
+                disabled={isLoading || preferenceMeta.branchOptions.length === 0}
+              >
+                <option value="">{t('preference.autoOption')}</option>
+                {preferenceMeta.branchOptions.map((option) => (
+                  <option key={option.shopId} value={option.shopId}>
+                    {option.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="space-y-2 text-sm">
+              <span className="font-medium text-foreground">
+                {t('preference.clusterLabel')}
+              </span>
+              <select
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground"
+                value={preferenceMeta.requestedCluster ?? ''}
+                onChange={(event) => handleClusterChange(event.target.value)}
+                disabled={isLoading || preferenceMeta.clusterOptions.length === 0}
+              >
+                <option value="">{t('preference.autoOption')}</option>
+                {preferenceMeta.clusterOptions.map((cluster) => (
+                  <option key={cluster} value={cluster}>
+                    {getClusterLabel(cluster)}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="outline">{activeModeLabel}</Badge>
+            {preferenceMeta.fallbackReasonCode !== undefined && (
+              <span className="text-sm text-muted-foreground">
+                {getFallbackMessage(preferenceMeta.fallbackReasonCode)}
+              </span>
+            )}
+          </div>
+        </div>
+      </section>
 
       {showBlockingUnavailable ? (
         <Card className="border border-border bg-card">
@@ -458,6 +691,8 @@ export default function DashboardPage() {
                     statusText={getStatusText(item)}
                     tone={getRowTone(item)}
                     emphasized
+                    reasonCodes={item.reasonCodes}
+                    getReasonLabel={getReasonLabel}
                   />
                 ))}
               </div>

--- a/app/[locale]/dashboard/page.tsx
+++ b/app/[locale]/dashboard/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { type ChangeEvent, useCallback, useEffect, useRef, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { AlertCircle, Clock, RefreshCw } from 'lucide-react';
@@ -236,6 +236,17 @@ function createEmptyPreferenceMeta(): RecommendationPreferenceMeta {
   };
 }
 
+function findBranchOption(
+  branchOptions: RecommendationBranchOption[],
+  shopId?: number
+): RecommendationBranchOption | undefined {
+  if (shopId === undefined) {
+    return undefined;
+  }
+
+  return branchOptions.find((option) => option.shopId === shopId);
+}
+
 export default function DashboardPage() {
   const t = useTranslations('dashboardQueue');
   const router = useRouter();
@@ -349,6 +360,20 @@ export default function DashboardPage() {
     errorMessage !== null &&
     queues.length > 0 &&
     snapshotStatus !== QUEUE_SNAPSHOT_STATUS.PARTIAL;
+  const selectedBranchOption = findBranchOption(
+    preferenceMeta.branchOptions,
+    preferenceMeta.requestedBranchShopId
+  );
+  const activeBranch = findBranchOption(
+    preferenceMeta.branchOptions,
+    preferenceMeta.activeBranchShopId
+  );
+  const branchSelectValue =
+    selectedBranchOption?.shopId.toString() ?? '';
+  const clusterSelectValue =
+    selectedBranchOption !== undefined
+      ? preferenceMeta.activeCluster ?? ''
+      : preferenceMeta.requestedCluster ?? '';
 
   const clusterLabelMap: Record<RecommendationCluster, string> = {
     HK_ISLAND_WEST: t('preference.clusterLabels.HK_ISLAND_WEST'),
@@ -410,10 +435,18 @@ export default function DashboardPage() {
           return;
         }
 
+        const selectedOption = preferenceMeta.branchOptions.find(
+          (option) => option.shopId === Number(nextValue)
+        );
+
         params.set('preferredBranch', nextValue);
+
+        if (selectedOption !== undefined) {
+          params.set('preferredCluster', selectedOption.cluster);
+        }
       });
     },
-    [replacePreferenceParams]
+    [preferenceMeta.branchOptions, replacePreferenceParams]
   );
 
   const handleClusterChange = useCallback(
@@ -438,10 +471,6 @@ export default function DashboardPage() {
       });
     },
     [preferenceMeta.branchOptions, preferenceMeta.requestedBranchShopId, replacePreferenceParams]
-  );
-
-  const activeBranch = preferenceMeta.branchOptions.find(
-    (option) => option.shopId === preferenceMeta.activeBranchShopId
   );
 
   const getFallbackMessage = useCallback(
@@ -566,8 +595,10 @@ export default function DashboardPage() {
               </span>
               <select
                 className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground"
-                value={preferenceMeta.requestedBranchShopId?.toString() ?? ''}
-                onChange={(event) => handleBranchChange(event.target.value)}
+                value={branchSelectValue}
+                onChange={(event: ChangeEvent<HTMLSelectElement>) =>
+                  handleBranchChange(event.target.value)
+                }
                 disabled={isLoading || preferenceMeta.branchOptions.length === 0}
               >
                 <option value="">{t('preference.autoOption')}</option>
@@ -585,8 +616,10 @@ export default function DashboardPage() {
               </span>
               <select
                 className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground"
-                value={preferenceMeta.requestedCluster ?? ''}
-                onChange={(event) => handleClusterChange(event.target.value)}
+                value={clusterSelectValue}
+                onChange={(event: ChangeEvent<HTMLSelectElement>) =>
+                  handleClusterChange(event.target.value)
+                }
                 disabled={isLoading || preferenceMeta.clusterOptions.length === 0}
               >
                 <option value="">{t('preference.autoOption')}</option>
@@ -596,6 +629,11 @@ export default function DashboardPage() {
                   </option>
                 ))}
               </select>
+              {selectedBranchOption !== undefined && (
+                <p className="text-xs text-muted-foreground">
+                  {t('preference.branchPriorityHint')}
+                </p>
+              )}
             </label>
           </div>
 

--- a/app/api/queues/route.ts
+++ b/app/api/queues/route.ts
@@ -4,12 +4,17 @@ import { fetchLiveStores } from '@/lib/live-stores';
 import {
   buildQueueSnapshot,
   buildUnavailableQueueSnapshot,
+  parseRecommendationPreference,
 } from '@/lib/queue-snapshot';
 import { QUEUE_SNAPSHOT_STATUS, QueueApiResponse } from '@/lib/types';
 
-export async function GET(): Promise<NextResponse<QueueApiResponse>> {
+export async function GET(request: Request): Promise<NextResponse<QueueApiResponse>> {
+  const preference = parseRecommendationPreference(
+    new URL(request.url).searchParams
+  );
+
   try {
-    const snapshot = buildQueueSnapshot(await fetchLiveStores());
+    const snapshot = buildQueueSnapshot(await fetchLiveStores(), preference);
     const statusCode =
       snapshot.status === QUEUE_SNAPSHOT_STATUS.SUCCESS
         ? 200
@@ -21,8 +26,11 @@ export async function GET(): Promise<NextResponse<QueueApiResponse>> {
   } catch (error) {
     console.error('Error in queues API:', error);
 
-    return NextResponse.json(buildUnavailableQueueSnapshot(new Date()), {
-      status: 503,
-    });
+    return NextResponse.json(
+      buildUnavailableQueueSnapshot(new Date(), 'STORE_DATA_UNAVAILABLE', preference),
+      {
+        status: 503,
+      }
+    );
   }
 }

--- a/lib/queue-recommendations.test.ts
+++ b/lib/queue-recommendations.test.ts
@@ -4,7 +4,10 @@ import { buildRecommendedQueues } from '@/lib/queue-recommendations';
 import {
   QueueItem,
   RECOMMENDATION_CLUSTERS,
+  RECOMMENDATION_MODES,
+  RECOMMENDATION_REASON_CODES,
   RecommendationCluster,
+  RecommendationPreferenceMeta,
   Store,
 } from '@/lib/types';
 
@@ -47,135 +50,77 @@ function createStoreMap(stores: Store[]): Map<number, Store> {
   return new Map(stores.map((store) => [store.shopId, store] as const));
 }
 
+function createPreference(
+  overrides: Partial<RecommendationPreferenceMeta> = {}
+): RecommendationPreferenceMeta {
+  return {
+    activeMode: RECOMMENDATION_MODES.AUTO,
+    branchOptions: [],
+    clusterOptions: [],
+    ...overrides,
+  };
+}
+
 describe('queue recommendations', () => {
-  it('anchors to the globally best eligible item when no preferred cluster exists', () => {
-    const islandWest = createQueueItem(1, 'Central', 1);
-    const islandEast = createQueueItem(2, 'North Point', 4);
-    const westKowloon = createQueueItem(3, 'Mong Kok', 2);
-    const eastKowloon = createQueueItem(4, 'Kwun Tong', 3);
+  it('keeps the preferred branch first and explains same-cluster follow-ups', () => {
+    const preferredBranch = createQueueItem(1, 'Jordan', 5);
+    const sameCluster = createQueueItem(2, 'Mong Kok', 1);
+    const adjacent = createQueueItem(3, 'Tsuen Wan', 2);
 
     const recommended = buildRecommendedQueues(
-      [eastKowloon, westKowloon, islandEast, islandWest],
-      createStoreMap([
-        createStore(1, RECOMMENDATION_CLUSTERS.HK_ISLAND_WEST),
-        createStore(2, RECOMMENDATION_CLUSTERS.HK_ISLAND_EAST),
-        createStore(3, RECOMMENDATION_CLUSTERS.WEST_KOWLOON),
-        createStore(4, RECOMMENDATION_CLUSTERS.EAST_KOWLOON),
-      ])
-    );
-
-    expect(recommended).toEqual([islandWest, westKowloon, islandEast]);
-  });
-
-  it('returns only preferred-cluster items when 3 or more eligible items exist there', () => {
-    const jordan = createQueueItem(1, 'Jordan', 2);
-    const mongKok = createQueueItem(2, 'Mong Kok', 2);
-    const tsimShaTsui = createQueueItem(3, 'Tsim Sha Tsui', 3);
-    const tsuenWan = createQueueItem(4, 'Tsuen Wan', 1);
-
-    const recommended = buildRecommendedQueues(
-      [tsimShaTsui, tsuenWan, mongKok, jordan],
-      createStoreMap([
-        createStore(1, RECOMMENDATION_CLUSTERS.WEST_KOWLOON),
-        createStore(2, RECOMMENDATION_CLUSTERS.WEST_KOWLOON),
-        createStore(3, RECOMMENDATION_CLUSTERS.WEST_KOWLOON),
-        createStore(4, RECOMMENDATION_CLUSTERS.TSUEN_KWAN_WEST),
-      ]),
-      RECOMMENDATION_CLUSTERS.WEST_KOWLOON
-    );
-
-    expect(recommended).toEqual([jordan, mongKok, tsimShaTsui]);
-  });
-
-  it('keeps preferred-cluster items ahead of fallback candidates with slightly lower queues', () => {
-    const jordan = createQueueItem(1, 'Jordan', 2);
-    const mongKok = createQueueItem(2, 'Mong Kok', 2);
-    const tsuenWan = createQueueItem(3, 'Tsuen Wan', 1);
-
-    const recommended = buildRecommendedQueues(
-      [tsuenWan, mongKok, jordan],
+      [adjacent, sameCluster, preferredBranch],
       createStoreMap([
         createStore(1, RECOMMENDATION_CLUSTERS.WEST_KOWLOON),
         createStore(2, RECOMMENDATION_CLUSTERS.WEST_KOWLOON),
         createStore(3, RECOMMENDATION_CLUSTERS.TSUEN_KWAN_WEST),
       ]),
-      RECOMMENDATION_CLUSTERS.WEST_KOWLOON
+      createPreference({
+        activeMode: RECOMMENDATION_MODES.BRANCH,
+        activeBranchShopId: 1,
+        activeCluster: RECOMMENDATION_CLUSTERS.WEST_KOWLOON,
+      })
     );
 
-    expect(recommended).toEqual([jordan, mongKok, tsuenWan]);
-  });
-
-  it('fills remaining slots from fallback scope after preferred-cluster candidates are exhausted', () => {
-    const jordan = createQueueItem(1, 'Jordan', 2);
-    const tsuenWan = createQueueItem(2, 'Tsuen Wan', 1);
-    const kwaiFong = createQueueItem(3, 'Kwai Fong', 3);
-
-    const recommended = buildRecommendedQueues(
-      [kwaiFong, tsuenWan, jordan],
-      createStoreMap([
-        createStore(1, RECOMMENDATION_CLUSTERS.WEST_KOWLOON),
-        createStore(2, RECOMMENDATION_CLUSTERS.TSUEN_KWAN_WEST),
-        createStore(3, RECOMMENDATION_CLUSTERS.TSUEN_KWAN_WEST),
-      ]),
-      RECOMMENDATION_CLUSTERS.WEST_KOWLOON
+    expect(recommended.items.map((item) => item.shopId)).toEqual([1, 2, 3]);
+    expect(recommended.items[0].reasonCodes).toContain(
+      RECOMMENDATION_REASON_CODES.PREFERRED_BRANCH
     );
-
-    expect(recommended).toEqual([jordan, tsuenWan, kwaiFong]);
+    expect(recommended.items[1].reasonCodes).toContain(
+      RECOMMENDATION_REASON_CODES.SAME_CLUSTER_AS_PREFERRED_BRANCH
+    );
+    expect(recommended.items[2].reasonCodes).toContain(
+      RECOMMENDATION_REASON_CODES.NEARBY_FALLBACK
+    );
   });
 
-  it('falls back from the preferred anchor scope when the preferred cluster has no eligible items', () => {
-    const tsuenWan = createQueueItem(1, 'Tsuen Wan', 1);
-    const kwaiFong = createQueueItem(2, 'Kwai Fong', 2);
-    const shaTin = createQueueItem(3, 'Sha Tin', 3);
+  it('anchors cluster mode to the selected cluster before adjacent fallback', () => {
+    const selectedClusterBest = createQueueItem(1, 'Kwun Tong', 2);
+    const selectedClusterSecond = createQueueItem(2, 'Wong Tai Sin', 3);
+    const nearbyFallback = createQueueItem(3, 'Sha Tin', 1);
 
     const recommended = buildRecommendedQueues(
-      [shaTin, kwaiFong, tsuenWan],
+      [nearbyFallback, selectedClusterSecond, selectedClusterBest],
       createStoreMap([
-        createStore(1, RECOMMENDATION_CLUSTERS.TSUEN_KWAN_WEST),
-        createStore(2, RECOMMENDATION_CLUSTERS.TSUEN_KWAN_WEST),
+        createStore(1, RECOMMENDATION_CLUSTERS.EAST_KOWLOON),
+        createStore(2, RECOMMENDATION_CLUSTERS.EAST_KOWLOON),
         createStore(3, RECOMMENDATION_CLUSTERS.SHA_TIN_BELT),
       ]),
-      RECOMMENDATION_CLUSTERS.WEST_KOWLOON
+      createPreference({
+        activeMode: RECOMMENDATION_MODES.CLUSTER,
+        activeCluster: RECOMMENDATION_CLUSTERS.EAST_KOWLOON,
+      })
     );
 
-    expect(recommended).toEqual([tsuenWan, kwaiFong, shaTin]);
-  });
-
-  it('falls back to the global eligible pool after 1-hop adjacent clusters are exhausted', () => {
-    const anchor = createQueueItem(1, 'Tseung Kwan O', 1);
-    const eastKowloon = createQueueItem(2, 'Kwun Tong', 2);
-    const westKowloon = createQueueItem(3, 'Jordan', 3);
-
-    const recommended = buildRecommendedQueues(
-      [westKowloon, eastKowloon, anchor],
-      createStoreMap([
-        createStore(1, RECOMMENDATION_CLUSTERS.TSEUNG_KWAN_O),
-        createStore(2, RECOMMENDATION_CLUSTERS.EAST_KOWLOON),
-        createStore(3, RECOMMENDATION_CLUSTERS.WEST_KOWLOON),
-      ])
+    expect(recommended.items.map((item) => item.shopId)).toEqual([1, 2, 3]);
+    expect(recommended.items[0].reasonCodes).toContain(
+      RECOMMENDATION_REASON_CODES.IN_SELECTED_CLUSTER
     );
-
-    expect(recommended).toEqual([anchor, eastKowloon, westKowloon]);
-  });
-
-  it('falls back to the remaining global eligible pool after exhausting 1-hop adjacency', () => {
-    const unknown = createQueueItem(1, 'Unknown', 1);
-    const islandWest = createQueueItem(2, 'Central', 2);
-    const westKowloon = createQueueItem(3, 'Jordan', 3);
-
-    const recommended = buildRecommendedQueues(
-      [westKowloon, islandWest, unknown],
-      createStoreMap([
-        createStore(1, RECOMMENDATION_CLUSTERS.UNKNOWN),
-        createStore(2, RECOMMENDATION_CLUSTERS.HK_ISLAND_WEST),
-        createStore(3, RECOMMENDATION_CLUSTERS.WEST_KOWLOON),
-      ])
+    expect(recommended.items[2].reasonCodes).toContain(
+      RECOMMENDATION_REASON_CODES.NEARBY_FALLBACK
     );
-
-    expect(recommended).toEqual([unknown, islandWest, westKowloon]);
   });
 
-  it('returns all eligible branches when fewer than 3 exist', () => {
+  it('returns deterministic auto recommendations with an active cluster', () => {
     const first = createQueueItem(1, 'Central', 0, 'IMMEDIATE');
     const second = createQueueItem(2, 'Jordan', 2);
 
@@ -184,43 +129,15 @@ describe('queue recommendations', () => {
       createStoreMap([
         createStore(1, RECOMMENDATION_CLUSTERS.HK_ISLAND_WEST),
         createStore(2, RECOMMENDATION_CLUSTERS.WEST_KOWLOON),
-      ])
+      ]),
+      createPreference()
     );
 
-    expect(recommended).toEqual([first, second]);
-  });
-
-  it('excludes non-eligible normalized queue items', () => {
-    const eligible = createQueueItem(1, 'Central', 1);
-    const unavailable = createQueueItem(2, 'Tai Po', null, 'UNAVAILABLE');
-    const closed = createQueueItem(3, 'Closed', null, 'INELIGIBLE');
-
-    const recommended = buildRecommendedQueues(
-      [eligible, unavailable, closed],
-      createStoreMap([
-        createStore(1, RECOMMENDATION_CLUSTERS.HK_ISLAND_WEST),
-        createStore(2, RECOMMENDATION_CLUSTERS.NORTH_NT),
-        createStore(3, RECOMMENDATION_CLUSTERS.UNKNOWN),
-      ])
+    expect(recommended.activeCluster).toBe(
+      RECOMMENDATION_CLUSTERS.HK_ISLAND_WEST
     );
-
-    expect(recommended).toEqual([eligible]);
-  });
-
-  it('pairs queue items to stores by shopId instead of array order when building the 1-hop scope', () => {
-    const islandWest = createQueueItem(1, 'Central', 2);
-    const eastKowloon = createQueueItem(2, 'Kwun Tong', 1);
-    const islandEast = createQueueItem(3, 'North Point', 3);
-
-    const recommended = buildRecommendedQueues(
-      [islandWest, eastKowloon, islandEast],
-      createStoreMap([
-        createStore(3, RECOMMENDATION_CLUSTERS.HK_ISLAND_EAST),
-        createStore(1, RECOMMENDATION_CLUSTERS.HK_ISLAND_WEST),
-        createStore(2, RECOMMENDATION_CLUSTERS.EAST_KOWLOON),
-      ])
+    expect(recommended.items[0].reasonCodes).toContain(
+      RECOMMENDATION_REASON_CODES.OPEN_NOW
     );
-
-    expect(recommended).toEqual([eastKowloon, islandEast, islandWest]);
   });
 });

--- a/lib/queue-recommendations.ts
+++ b/lib/queue-recommendations.ts
@@ -2,18 +2,33 @@ import { compareQueueItems } from '@/lib/queue-items';
 import { CLUSTER_ADJACENCY } from '@/lib/recommendation-clusters';
 import {
   QueueItem,
-  QueueRecommendationState,
+  RECOMMENDATION_MODES,
+  RECOMMENDATION_REASON_CODES,
+  RecommendedQueueItem,
   RecommendationCluster,
+  RecommendationPreferenceMeta,
+  RecommendationReasonCode,
   Store,
 } from '@/lib/types';
 
-const ELIGIBLE_RECOMMENDATION_STATES: QueueRecommendationState[] = [
-  'IMMEDIATE',
-  'WAITING',
-];
+type RecommendationScope =
+  | 'preferred-branch'
+  | 'same-cluster'
+  | 'selected-cluster'
+  | 'adjacent'
+  | 'global'
+  | 'auto';
+
+interface RecommendationBuildResult {
+  items: RecommendedQueueItem[];
+  activeCluster?: RecommendationCluster;
+}
 
 function isEligibleRecommendation(item: QueueItem): boolean {
-  return ELIGIBLE_RECOMMENDATION_STATES.includes(item.recommendationState);
+  return (
+    item.recommendationState === 'IMMEDIATE' ||
+    item.recommendationState === 'WAITING'
+  );
 }
 
 function getClusterForItem(
@@ -21,6 +36,17 @@ function getClusterForItem(
   storesByShopId: Map<number, Store>
 ): RecommendationCluster | null {
   return storesByShopId.get(item.shopId)?.recommendationCluster ?? null;
+}
+
+function getEligibleCandidates(
+  data: QueueItem[],
+  storesByShopId: Map<number, Store>
+): QueueItem[] {
+  return data.filter(
+    (item) =>
+      isEligibleRecommendation(item) &&
+      getClusterForItem(item, storesByShopId) !== null
+  );
 }
 
 function getAnchorCluster(
@@ -38,29 +64,7 @@ function getAnchorCluster(
   return getClusterForItem(bestCandidate, storesByShopId);
 }
 
-function getEligibleCandidates(
-  data: QueueItem[],
-  storesByShopId: Map<number, Store>
-): QueueItem[] {
-  return data.filter(
-    (item) =>
-      isEligibleRecommendation(item) &&
-      getClusterForItem(item, storesByShopId) !== null
-  );
-}
-
-function getCandidatesInClusters(
-  candidates: QueueItem[],
-  relevantClusters: Set<RecommendationCluster>,
-  storesByShopId: Map<number, Store>
-): QueueItem[] {
-  return candidates.filter((item) => {
-    const cluster = getClusterForItem(item, storesByShopId);
-    return cluster !== null && relevantClusters.has(cluster);
-  });
-}
-
-function getEligibleItemsInCluster(
+function getCandidatesInCluster(
   candidates: QueueItem[],
   storesByShopId: Map<number, Store>,
   cluster: RecommendationCluster
@@ -70,104 +74,222 @@ function getEligibleItemsInCluster(
     .sort(compareQueueItems);
 }
 
-function getScopedFallbackRecommendations(
+function getCandidatesInClusters(
   candidates: QueueItem[],
-  storesByShopId: Map<number, Store>,
-  anchorCluster: RecommendationCluster,
-  excludedShopIds: Set<number>
-): QueueItem[] {
-  const adjacentClusters = new Set<RecommendationCluster>(
-    CLUSTER_ADJACENCY[anchorCluster]
-  );
-  return getCandidatesInClusters(
-    candidates,
-    adjacentClusters,
-    storesByShopId
-  )
-    .filter((item) => !excludedShopIds.has(item.shopId))
-    .sort(compareQueueItems);
-}
-
-function getGlobalFallbackRecommendations(
-  candidates: QueueItem[],
-  excludedShopIds: Set<number>
+  relevantClusters: Set<RecommendationCluster>,
+  storesByShopId: Map<number, Store>
 ): QueueItem[] {
   return candidates
-    .filter((item) => !excludedShopIds.has(item.shopId))
+    .filter((item) => {
+      const cluster = getClusterForItem(item, storesByShopId);
+      return cluster !== null && relevantClusters.has(cluster);
+    })
     .sort(compareQueueItems);
 }
 
-function buildPrimaryThenFallbackRecommendations(
+function buildReasonCodes(
+  item: QueueItem,
+  storesByShopId: Map<number, Store>,
+  preference: RecommendationPreferenceMeta,
+  scope: RecommendationScope
+): RecommendationReasonCode[] {
+  const reasonCodes: RecommendationReasonCode[] = [];
+  const itemCluster = getClusterForItem(item, storesByShopId);
+
+  if (
+    preference.activeMode === RECOMMENDATION_MODES.BRANCH &&
+    preference.activeBranchShopId === item.shopId
+  ) {
+    reasonCodes.push(RECOMMENDATION_REASON_CODES.PREFERRED_BRANCH);
+  } else if (
+    preference.activeMode === RECOMMENDATION_MODES.BRANCH &&
+    scope === 'same-cluster'
+  ) {
+    reasonCodes.push(
+      RECOMMENDATION_REASON_CODES.SAME_CLUSTER_AS_PREFERRED_BRANCH
+    );
+  } else if (
+    preference.activeMode === RECOMMENDATION_MODES.CLUSTER &&
+    itemCluster === preference.activeCluster
+  ) {
+    reasonCodes.push(RECOMMENDATION_REASON_CODES.IN_SELECTED_CLUSTER);
+  } else if (
+    scope === 'adjacent' &&
+    preference.activeCluster !== undefined &&
+    itemCluster !== null
+  ) {
+    reasonCodes.push(RECOMMENDATION_REASON_CODES.NEARBY_FALLBACK);
+  } else if (scope === 'global') {
+    reasonCodes.push(RECOMMENDATION_REASON_CODES.BEST_FALLBACK);
+  }
+
+  if (item.queueCount === 0) {
+    reasonCodes.push(RECOMMENDATION_REASON_CODES.OPEN_NOW);
+  } else if (item.queueCount !== null && item.queueCount <= 15) {
+    reasonCodes.push(RECOMMENDATION_REASON_CODES.SHORT_WAIT);
+  }
+
+  if (reasonCodes.length === 0) {
+    reasonCodes.push(RECOMMENDATION_REASON_CODES.BEST_FALLBACK);
+  }
+
+  return reasonCodes;
+}
+
+function toRecommendedItem(
+  item: QueueItem,
+  storesByShopId: Map<number, Store>,
+  preference: RecommendationPreferenceMeta,
+  scope: RecommendationScope
+): RecommendedQueueItem {
+  return {
+    ...item,
+    reasonCodes: buildReasonCodes(item, storesByShopId, preference, scope),
+  };
+}
+
+function appendCandidates(
+  selected: Array<{ item: QueueItem; scope: RecommendationScope }>,
+  candidates: QueueItem[],
+  scope: RecommendationScope
+): Array<{ item: QueueItem; scope: RecommendationScope }> {
+  const selectedShopIds = new Set(selected.map((entry) => entry.item.shopId));
+
+  candidates.forEach((candidate) => {
+    if (!selectedShopIds.has(candidate.shopId) && selected.length < 3) {
+      selected.push({ item: candidate, scope });
+      selectedShopIds.add(candidate.shopId);
+    }
+  });
+
+  return selected;
+}
+
+function buildClusterRecommendations(
   candidates: QueueItem[],
   storesByShopId: Map<number, Store>,
-  primaryCluster: RecommendationCluster
-): QueueItem[] {
-  const primaryCandidates = getEligibleItemsInCluster(
+  preference: RecommendationPreferenceMeta,
+  primaryCluster: RecommendationCluster,
+  primaryScope: RecommendationScope
+): RecommendationBuildResult {
+  const selected: Array<{ item: QueueItem; scope: RecommendationScope }> = [];
+  const primaryCandidates = getCandidatesInCluster(
     candidates,
     storesByShopId,
     primaryCluster
   );
-  const selectedPrimary = primaryCandidates.slice(0, 3);
+  appendCandidates(selected, primaryCandidates, primaryScope);
 
-  if (selectedPrimary.length === 3) {
-    return selectedPrimary;
+  if (selected.length < 3) {
+    const adjacentClusters = new Set<RecommendationCluster>(
+      CLUSTER_ADJACENCY[primaryCluster]
+    );
+    const adjacentCandidates = getCandidatesInClusters(
+      candidates,
+      adjacentClusters,
+      storesByShopId
+    );
+    appendCandidates(selected, adjacentCandidates, 'adjacent');
   }
 
-  const selectedShopIds = new Set(selectedPrimary.map((item) => item.shopId));
-  const fallbackCandidates = getScopedFallbackRecommendations(
-    candidates,
-    storesByShopId,
-    primaryCluster,
-    selectedShopIds
-  );
-  const selectedWithAdjacentFallback = [
-    ...selectedPrimary,
-    ...fallbackCandidates,
-  ].slice(0, 3);
-
-  if (selectedWithAdjacentFallback.length === 3) {
-    return selectedWithAdjacentFallback;
+  if (selected.length < 3) {
+    appendCandidates(selected, [...candidates].sort(compareQueueItems), 'global');
   }
 
-  const adjacentFallbackShopIds = new Set([
-    ...Array.from(selectedShopIds),
-    ...fallbackCandidates.map((item) => item.shopId),
-  ]);
-  const globalFallbackCandidates = getGlobalFallbackRecommendations(
-    candidates,
-    adjacentFallbackShopIds
+  return {
+    activeCluster: primaryCluster,
+    items: selected.map(({ item, scope }) =>
+      toRecommendedItem(item, storesByShopId, preference, scope)
+    ),
+  };
+}
+
+function buildBranchRecommendations(
+  candidates: QueueItem[],
+  storesByShopId: Map<number, Store>,
+  preference: RecommendationPreferenceMeta
+): RecommendationBuildResult {
+  const selected: Array<{ item: QueueItem; scope: RecommendationScope }> = [];
+  const preferredBranch = candidates.find(
+    (item) => item.shopId === preference.activeBranchShopId
   );
 
-  return [...selectedWithAdjacentFallback, ...globalFallbackCandidates].slice(
-    0,
-    3
-  );
+  if (preferredBranch) {
+    selected.push({ item: preferredBranch, scope: 'preferred-branch' });
+  }
+
+  if (preference.activeCluster !== undefined) {
+    const sameClusterCandidates = getCandidatesInCluster(
+      candidates,
+      storesByShopId,
+      preference.activeCluster
+    );
+    appendCandidates(selected, sameClusterCandidates, 'same-cluster');
+
+    if (selected.length < 3) {
+      const adjacentClusters = new Set<RecommendationCluster>(
+        CLUSTER_ADJACENCY[preference.activeCluster]
+      );
+      const adjacentCandidates = getCandidatesInClusters(
+        candidates,
+        adjacentClusters,
+        storesByShopId
+      );
+      appendCandidates(selected, adjacentCandidates, 'adjacent');
+    }
+  }
+
+  if (selected.length < 3) {
+    appendCandidates(selected, [...candidates].sort(compareQueueItems), 'global');
+  }
+
+  return {
+    activeCluster: preference.activeCluster,
+    items: selected.map(({ item, scope }) =>
+      toRecommendedItem(item, storesByShopId, preference, scope)
+    ),
+  };
 }
 
 export function buildRecommendedQueues(
   data: QueueItem[],
   storesByShopId: Map<number, Store>,
-  preferredCluster?: RecommendationCluster
-): QueueItem[] {
+  preference: RecommendationPreferenceMeta
+): RecommendationBuildResult {
   const eligibleCandidates = getEligibleCandidates(data, storesByShopId);
 
-  if (preferredCluster) {
-    return buildPrimaryThenFallbackRecommendations(
+  if (preference.activeMode === RECOMMENDATION_MODES.BRANCH) {
+    return buildBranchRecommendations(
       eligibleCandidates,
       storesByShopId,
-      preferredCluster
+      preference
+    );
+  }
+
+  if (
+    preference.activeMode === RECOMMENDATION_MODES.CLUSTER &&
+    preference.activeCluster !== undefined
+  ) {
+    return buildClusterRecommendations(
+      eligibleCandidates,
+      storesByShopId,
+      preference,
+      preference.activeCluster,
+      'selected-cluster'
     );
   }
 
   const anchorCluster = getAnchorCluster(eligibleCandidates, storesByShopId);
 
   if (!anchorCluster) {
-    return [];
+    return { items: [] };
   }
 
-  return buildPrimaryThenFallbackRecommendations(
+  return buildClusterRecommendations(
     eligibleCandidates,
     storesByShopId,
-    anchorCluster
+    preference,
+    anchorCluster,
+    'auto'
   );
 }

--- a/lib/queue-snapshot.test.ts
+++ b/lib/queue-snapshot.test.ts
@@ -5,7 +5,12 @@ import {
   buildQueueSnapshot,
   buildUnavailableQueueSnapshot,
 } from '@/lib/queue-snapshot';
-import { RECOMMENDATION_CLUSTERS, Store } from '@/lib/types';
+import {
+  RECOMMENDATION_CLUSTERS,
+  RECOMMENDATION_MODES,
+  RECOMMENDATION_REASON_CODES,
+  Store,
+} from '@/lib/types';
 
 function createStore(
   shopId: number,
@@ -56,6 +61,7 @@ describe('queue snapshot builder', () => {
     expect(snapshot.errorCode).toBeUndefined();
     expect(snapshot.meta.failedQueueFetches).toBe(0);
     expect(snapshot.recommended).toHaveLength(2);
+    expect(snapshot.preferences.activeMode).toBe(RECOMMENDATION_MODES.AUTO);
   });
 
   it('returns partial when store metadata exists but some queue fetches fail', () => {
@@ -91,12 +97,37 @@ describe('queue snapshot builder', () => {
     expect(snapshot.groups.unavailable).toHaveLength(1);
   });
 
+  it('returns branch preference meta and explainability when a preferred branch is requested', () => {
+    const snapshot = buildQueueSnapshot(
+      createLiveStoresResult({
+        stores: [
+          createStore(1, 4),
+          createStore(2, 1),
+          createStore(3, 2),
+        ],
+        totalStores: 3,
+        successfulQueueFetches: 3,
+      }),
+      {
+        preferredBranchShopId: 1,
+      }
+    );
+
+    expect(snapshot.preferences.activeMode).toBe(RECOMMENDATION_MODES.BRANCH);
+    expect(snapshot.preferences.activeBranchShopId).toBe(1);
+    expect(snapshot.recommended[0].shopId).toBe(1);
+    expect(snapshot.recommended[0].reasonCodes).toContain(
+      RECOMMENDATION_REASON_CODES.PREFERRED_BRANCH
+    );
+  });
+
   it('returns unavailable when no stores are available', () => {
     const snapshot = buildQueueSnapshot(createLiveStoresResult());
 
     expect(snapshot.status).toBe('unavailable');
     expect(snapshot.errorCode).toBe('STORE_DATA_UNAVAILABLE');
     expect(snapshot.data).toEqual([]);
+    expect(snapshot.preferences.activeMode).toBe(RECOMMENDATION_MODES.AUTO);
   });
 
   it('builds an explicit unavailable snapshot for route failures', () => {

--- a/lib/queue-snapshot.test.ts
+++ b/lib/queue-snapshot.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@/lib/queue-snapshot';
 import {
   RECOMMENDATION_CLUSTERS,
+  RECOMMENDATION_FALLBACK_REASON_CODES,
   RECOMMENDATION_MODES,
   RECOMMENDATION_REASON_CODES,
   Store,
@@ -115,6 +116,101 @@ describe('queue snapshot builder', () => {
 
     expect(snapshot.preferences.activeMode).toBe(RECOMMENDATION_MODES.BRANCH);
     expect(snapshot.preferences.activeBranchShopId).toBe(1);
+    expect(snapshot.recommended[0].shopId).toBe(1);
+    expect(snapshot.recommended[0].reasonCodes).toContain(
+      RECOMMENDATION_REASON_CODES.PREFERRED_BRANCH
+    );
+  });
+
+  it('returns explicit response preference metadata when branch input falls back to cluster', () => {
+    const snapshot = buildQueueSnapshot(
+      createLiveStoresResult({
+        stores: [
+          createStore(1, Number.NaN),
+          {
+            ...createStore(2, 1),
+            recommendationCluster: RECOMMENDATION_CLUSTERS.EAST_KOWLOON,
+          },
+        ],
+        totalStores: 2,
+        successfulQueueFetches: 1,
+        failedQueueFetches: 1,
+      }),
+      {
+        preferredBranchShopId: 1,
+        preferredCluster: RECOMMENDATION_CLUSTERS.EAST_KOWLOON,
+      }
+    );
+
+    expect(snapshot.preferences.requestedBranchShopId).toBe(1);
+    expect(snapshot.preferences.requestedCluster).toBe(
+      RECOMMENDATION_CLUSTERS.EAST_KOWLOON
+    );
+    expect(snapshot.preferences.activeMode).toBe(RECOMMENDATION_MODES.CLUSTER);
+    expect(snapshot.preferences.activeBranchShopId).toBeUndefined();
+    expect(snapshot.preferences.activeCluster).toBe(
+      RECOMMENDATION_CLUSTERS.EAST_KOWLOON
+    );
+    expect(snapshot.preferences.fallbackReasonCode).toBe(
+      RECOMMENDATION_FALLBACK_REASON_CODES.PREFERRED_BRANCH_INELIGIBLE
+    );
+  });
+
+  it('falls back to auto in response metadata when the requested cluster has no eligible branches', () => {
+    const snapshot = buildQueueSnapshot(
+      createLiveStoresResult({
+        stores: [
+          {
+            ...createStore(1, Number.NaN),
+            recommendationCluster: RECOMMENDATION_CLUSTERS.EAST_KOWLOON,
+          },
+          createStore(2, 1),
+        ],
+        totalStores: 2,
+        successfulQueueFetches: 1,
+        failedQueueFetches: 1,
+      }),
+      {
+        preferredCluster: RECOMMENDATION_CLUSTERS.EAST_KOWLOON,
+      }
+    );
+
+    expect(snapshot.preferences.requestedCluster).toBe(
+      RECOMMENDATION_CLUSTERS.EAST_KOWLOON
+    );
+    expect(snapshot.preferences.activeMode).toBe(RECOMMENDATION_MODES.AUTO);
+    expect(snapshot.preferences.activeCluster).toBe(RECOMMENDATION_CLUSTERS.WEST_KOWLOON);
+    expect(snapshot.preferences.fallbackReasonCode).toBe(
+      RECOMMENDATION_FALLBACK_REASON_CODES.PREFERRED_CLUSTER_UNAVAILABLE
+    );
+  });
+
+  it('keeps backend preference resolution authoritative when URL inputs conflict', () => {
+    const snapshot = buildQueueSnapshot(
+      createLiveStoresResult({
+        stores: [
+          createStore(1, 1),
+          {
+            ...createStore(2, 0),
+            recommendationCluster: RECOMMENDATION_CLUSTERS.EAST_KOWLOON,
+          },
+        ],
+        totalStores: 2,
+        successfulQueueFetches: 2,
+      }),
+      {
+        preferredBranchShopId: 1,
+        preferredCluster: RECOMMENDATION_CLUSTERS.EAST_KOWLOON,
+      }
+    );
+
+    expect(snapshot.preferences.requestedBranchShopId).toBe(1);
+    expect(snapshot.preferences.requestedCluster).toBe(
+      RECOMMENDATION_CLUSTERS.EAST_KOWLOON
+    );
+    expect(snapshot.preferences.activeMode).toBe(RECOMMENDATION_MODES.BRANCH);
+    expect(snapshot.preferences.activeBranchShopId).toBe(1);
+    expect(snapshot.preferences.activeCluster).toBe(RECOMMENDATION_CLUSTERS.WEST_KOWLOON);
     expect(snapshot.recommended[0].shopId).toBe(1);
     expect(snapshot.recommended[0].reasonCodes).toContain(
       RECOMMENDATION_REASON_CODES.PREFERRED_BRANCH

--- a/lib/queue-snapshot.ts
+++ b/lib/queue-snapshot.ts
@@ -1,11 +1,16 @@
 import type { LiveStoresResult } from '@/lib/live-stores';
 import { buildQueueItem, compareQueueItems } from '@/lib/queue-items';
+import {
+  parseRecommendationPreference,
+  resolveRecommendationPreference,
+} from '@/lib/recommendation-preferences';
 import { buildRecommendedQueues } from '@/lib/queue-recommendations';
 import { buildQueueGroups, createEmptyQueueGroups } from '@/lib/queue-response';
 import {
   QUEUE_SNAPSHOT_STATUS,
   QueueApiResponse,
   QueueSnapshotStatus,
+  RecommendationPreferenceInput,
 } from '@/lib/types';
 
 function getQueueSnapshotStatus(
@@ -24,7 +29,8 @@ function getQueueSnapshotStatus(
 
 export function buildUnavailableQueueSnapshot(
   updatedAt: Date,
-  errorCode = 'STORE_DATA_UNAVAILABLE'
+  errorCode = 'STORE_DATA_UNAVAILABLE',
+  preferenceInput: RecommendationPreferenceInput = {}
 ): QueueApiResponse {
   return {
     status: QUEUE_SNAPSHOT_STATUS.UNAVAILABLE,
@@ -40,16 +46,24 @@ export function buildUnavailableQueueSnapshot(
       successfulQueueFetches: 0,
       failedQueueFetches: 0,
     },
+    preferences: {
+      requestedBranchShopId: preferenceInput.preferredBranchShopId,
+      requestedCluster: preferenceInput.preferredCluster,
+      activeMode: 'auto',
+      branchOptions: [],
+      clusterOptions: [],
+    },
   };
 }
 
 export function buildQueueSnapshot(
-  liveStores: LiveStoresResult
+  liveStores: LiveStoresResult,
+  preferenceInput: RecommendationPreferenceInput = {}
 ): QueueApiResponse {
   const status = getQueueSnapshotStatus(liveStores);
 
   if (status === QUEUE_SNAPSHOT_STATUS.UNAVAILABLE) {
-    return buildUnavailableQueueSnapshot(liveStores.timestamp);
+    return buildUnavailableQueueSnapshot(liveStores.timestamp, 'STORE_DATA_UNAVAILABLE', preferenceInput);
   }
 
   const storesByShopId = new Map(
@@ -65,7 +79,16 @@ export function buildQueueSnapshot(
       )
     )
     .sort(compareQueueItems);
-  const recommended = buildRecommendedQueues(data, storesByShopId);
+  const preference = resolveRecommendationPreference(
+    preferenceInput,
+    data,
+    storesByShopId
+  );
+  const recommendationResult = buildRecommendedQueues(
+    data,
+    storesByShopId,
+    preference
+  );
   const groups = buildQueueGroups(data);
   const warnings =
     status === QUEUE_SNAPSHOT_STATUS.PARTIAL
@@ -80,7 +103,7 @@ export function buildQueueSnapshot(
     status,
     updatedAt: liveStores.timestamp.toISOString(),
     data,
-    recommended,
+    recommended: recommendationResult.items,
     groups,
     warnings,
     partialData: status === QUEUE_SNAPSHOT_STATUS.PARTIAL,
@@ -95,5 +118,12 @@ export function buildQueueSnapshot(
       successfulQueueFetches: liveStores.successfulQueueFetches,
       failedQueueFetches: liveStores.failedQueueFetches,
     },
+    preferences: {
+      ...preference,
+      activeCluster:
+        preference.activeCluster ?? recommendationResult.activeCluster,
+    },
   };
 }
+
+export { parseRecommendationPreference };

--- a/lib/recommendation-preferences.test.ts
+++ b/lib/recommendation-preferences.test.ts
@@ -58,6 +58,24 @@ describe('recommendation preferences', () => {
     });
   });
 
+  it('ignores missing or invalid query-param values during parsing', () => {
+    const invalidBranchParams = new URLSearchParams(
+      'preferredBranch=abc&preferredCluster=NOT_A_CLUSTER'
+    );
+    const missingBranchParams = new URLSearchParams(
+      'preferredCluster=EAST_KOWLOON'
+    );
+
+    expect(parseRecommendationPreference(invalidBranchParams)).toEqual({
+      preferredBranchShopId: undefined,
+      preferredCluster: undefined,
+    });
+    expect(parseRecommendationPreference(missingBranchParams)).toEqual({
+      preferredBranchShopId: undefined,
+      preferredCluster: RECOMMENDATION_CLUSTERS.EAST_KOWLOON,
+    });
+  });
+
   it('activates branch mode when the preferred branch is eligible', () => {
     const preference = resolveRecommendationPreference(
       {
@@ -76,7 +94,7 @@ describe('recommendation preferences', () => {
     expect(preference.activeCluster).toBe(RECOMMENDATION_CLUSTERS.WEST_KOWLOON);
   });
 
-  it('falls back from invalid branch to cluster mode when a valid cluster exists', () => {
+  it('falls back from an ineligible preferred branch to cluster mode when a valid cluster exists', () => {
     const preference = resolveRecommendationPreference(
       {
         preferredBranchShopId: 1,
@@ -93,6 +111,26 @@ describe('recommendation preferences', () => {
     expect(preference.activeCluster).toBe(RECOMMENDATION_CLUSTERS.EAST_KOWLOON);
     expect(preference.fallbackReasonCode).toBe(
       RECOMMENDATION_FALLBACK_REASON_CODES.PREFERRED_BRANCH_INELIGIBLE
+    );
+  });
+
+  it('falls back from a missing preferred branch to cluster mode when a valid cluster exists', () => {
+    const preference = resolveRecommendationPreference(
+      {
+        preferredBranchShopId: 99,
+        preferredCluster: RECOMMENDATION_CLUSTERS.EAST_KOWLOON,
+      },
+      [createQueueItem(2)],
+      createStoreMap([createStore(2, RECOMMENDATION_CLUSTERS.EAST_KOWLOON)])
+    );
+
+    expect(preference.requestedBranchShopId).toBe(99);
+    expect(preference.requestedCluster).toBe(RECOMMENDATION_CLUSTERS.EAST_KOWLOON);
+    expect(preference.activeMode).toBe(RECOMMENDATION_MODES.CLUSTER);
+    expect(preference.activeCluster).toBe(RECOMMENDATION_CLUSTERS.EAST_KOWLOON);
+    expect(preference.activeBranchShopId).toBeUndefined();
+    expect(preference.fallbackReasonCode).toBe(
+      RECOMMENDATION_FALLBACK_REASON_CODES.PREFERRED_BRANCH_NOT_FOUND
     );
   });
 
@@ -113,5 +151,42 @@ describe('recommendation preferences', () => {
     expect(preference.fallbackReasonCode).toBe(
       RECOMMENDATION_FALLBACK_REASON_CODES.PREFERRED_BRANCH_INELIGIBLE
     );
+  });
+
+  it('falls back from an unavailable cluster to auto mode when no eligible cluster candidates exist', () => {
+    const preference = resolveRecommendationPreference(
+      {
+        preferredCluster: RECOMMENDATION_CLUSTERS.EAST_KOWLOON,
+      },
+      [createQueueItem(2, 'UNAVAILABLE')],
+      createStoreMap([createStore(2, RECOMMENDATION_CLUSTERS.EAST_KOWLOON)])
+    );
+
+    expect(preference.activeMode).toBe(RECOMMENDATION_MODES.AUTO);
+    expect(preference.activeCluster).toBeUndefined();
+    expect(preference.fallbackReasonCode).toBe(
+      RECOMMENDATION_FALLBACK_REASON_CODES.PREFERRED_CLUSTER_UNAVAILABLE
+    );
+  });
+
+  it('keeps backend resolution authoritative when branch and cluster URL inputs conflict', () => {
+    const preference = resolveRecommendationPreference(
+      {
+        preferredBranchShopId: 1,
+        preferredCluster: RECOMMENDATION_CLUSTERS.EAST_KOWLOON,
+      },
+      [createQueueItem(1), createQueueItem(2)],
+      createStoreMap([
+        createStore(1, RECOMMENDATION_CLUSTERS.WEST_KOWLOON),
+        createStore(2, RECOMMENDATION_CLUSTERS.EAST_KOWLOON),
+      ])
+    );
+
+    expect(preference.requestedBranchShopId).toBe(1);
+    expect(preference.requestedCluster).toBe(RECOMMENDATION_CLUSTERS.EAST_KOWLOON);
+    expect(preference.activeMode).toBe(RECOMMENDATION_MODES.BRANCH);
+    expect(preference.activeBranchShopId).toBe(1);
+    expect(preference.activeCluster).toBe(RECOMMENDATION_CLUSTERS.WEST_KOWLOON);
+    expect(preference.fallbackReasonCode).toBeUndefined();
   });
 });

--- a/lib/recommendation-preferences.test.ts
+++ b/lib/recommendation-preferences.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  parseRecommendationPreference,
+  resolveRecommendationPreference,
+} from '@/lib/recommendation-preferences';
+import {
+  QueueItem,
+  RECOMMENDATION_CLUSTERS,
+  RECOMMENDATION_FALLBACK_REASON_CODES,
+  RECOMMENDATION_MODES,
+  Store,
+} from '@/lib/types';
+
+function createQueueItem(
+  shopId: number,
+  recommendationState: QueueItem['recommendationState'] = 'WAITING'
+): QueueItem {
+  return {
+    shopId,
+    name: `Store ${shopId}`,
+    storeStatus: recommendationState === 'INELIGIBLE' ? 'CLOSED' : 'OPEN',
+    queueCount: recommendationState === 'UNAVAILABLE' ? null : 2,
+    level: 'LOW',
+    recommendationState,
+  };
+}
+
+function createStore(shopId: number, cluster = RECOMMENDATION_CLUSTERS.WEST_KOWLOON): Store {
+  return {
+    shopId,
+    name: `Store ${shopId}`,
+    nameEn: `Store ${shopId}`,
+    address: '',
+    region: '',
+    area: '',
+    recommendationCluster: cluster,
+    storeStatus: 'OPEN',
+    waitingGroup: 2,
+    storeQueue: [],
+    timestamp: new Date('2026-01-01T00:00:00.000Z'),
+  };
+}
+
+function createStoreMap(stores: Store[]): Map<number, Store> {
+  return new Map(stores.map((store) => [store.shopId, store] as const));
+}
+
+describe('recommendation preferences', () => {
+  it('parses valid branch and cluster params from the URL', () => {
+    const params = new URLSearchParams(
+      'preferredBranch=12&preferredCluster=WEST_KOWLOON'
+    );
+
+    expect(parseRecommendationPreference(params)).toEqual({
+      preferredBranchShopId: 12,
+      preferredCluster: RECOMMENDATION_CLUSTERS.WEST_KOWLOON,
+    });
+  });
+
+  it('activates branch mode when the preferred branch is eligible', () => {
+    const preference = resolveRecommendationPreference(
+      {
+        preferredBranchShopId: 1,
+        preferredCluster: RECOMMENDATION_CLUSTERS.EAST_KOWLOON,
+      },
+      [createQueueItem(1), createQueueItem(2)],
+      createStoreMap([
+        createStore(1, RECOMMENDATION_CLUSTERS.WEST_KOWLOON),
+        createStore(2, RECOMMENDATION_CLUSTERS.EAST_KOWLOON),
+      ])
+    );
+
+    expect(preference.activeMode).toBe(RECOMMENDATION_MODES.BRANCH);
+    expect(preference.activeBranchShopId).toBe(1);
+    expect(preference.activeCluster).toBe(RECOMMENDATION_CLUSTERS.WEST_KOWLOON);
+  });
+
+  it('falls back from invalid branch to cluster mode when a valid cluster exists', () => {
+    const preference = resolveRecommendationPreference(
+      {
+        preferredBranchShopId: 1,
+        preferredCluster: RECOMMENDATION_CLUSTERS.EAST_KOWLOON,
+      },
+      [createQueueItem(1, 'INELIGIBLE'), createQueueItem(2)],
+      createStoreMap([
+        createStore(1, RECOMMENDATION_CLUSTERS.WEST_KOWLOON),
+        createStore(2, RECOMMENDATION_CLUSTERS.EAST_KOWLOON),
+      ])
+    );
+
+    expect(preference.activeMode).toBe(RECOMMENDATION_MODES.CLUSTER);
+    expect(preference.activeCluster).toBe(RECOMMENDATION_CLUSTERS.EAST_KOWLOON);
+    expect(preference.fallbackReasonCode).toBe(
+      RECOMMENDATION_FALLBACK_REASON_CODES.PREFERRED_BRANCH_INELIGIBLE
+    );
+  });
+
+  it('falls back to auto mode when preferred scope has no eligible candidates', () => {
+    const preference = resolveRecommendationPreference(
+      {
+        preferredBranchShopId: 1,
+        preferredCluster: RECOMMENDATION_CLUSTERS.EAST_KOWLOON,
+      },
+      [createQueueItem(1, 'INELIGIBLE'), createQueueItem(2, 'UNAVAILABLE')],
+      createStoreMap([
+        createStore(1, RECOMMENDATION_CLUSTERS.WEST_KOWLOON),
+        createStore(2, RECOMMENDATION_CLUSTERS.EAST_KOWLOON),
+      ])
+    );
+
+    expect(preference.activeMode).toBe(RECOMMENDATION_MODES.AUTO);
+    expect(preference.fallbackReasonCode).toBe(
+      RECOMMENDATION_FALLBACK_REASON_CODES.PREFERRED_BRANCH_INELIGIBLE
+    );
+  });
+});

--- a/lib/recommendation-preferences.ts
+++ b/lib/recommendation-preferences.ts
@@ -1,0 +1,183 @@
+import {
+  QueueItem,
+  RECOMMENDATION_CLUSTERS,
+  RECOMMENDATION_FALLBACK_REASON_CODES,
+  RECOMMENDATION_MODES,
+  RecommendationBranchOption,
+  RecommendationCluster,
+  RecommendationFallbackReasonCode,
+  RecommendationMode,
+  RecommendationPreferenceInput,
+  RecommendationPreferenceMeta,
+  Store,
+} from '@/lib/types';
+
+function isEligibleRecommendation(item: QueueItem): boolean {
+  return (
+    item.recommendationState === 'IMMEDIATE' ||
+    item.recommendationState === 'WAITING'
+  );
+}
+
+function isRecommendationCluster(
+  value: string
+): value is RecommendationCluster {
+  return Object.values(RECOMMENDATION_CLUSTERS).includes(
+    value as RecommendationCluster
+  );
+}
+
+export function parseRecommendationPreference(
+  searchParams: URLSearchParams
+): RecommendationPreferenceInput {
+  const preferredBranchValue = searchParams.get('preferredBranch');
+  const preferredClusterValue = searchParams.get('preferredCluster');
+
+  const preferredBranchShopId =
+    preferredBranchValue !== null &&
+    /^\d+$/.test(preferredBranchValue) &&
+    Number(preferredBranchValue) > 0
+      ? Number(preferredBranchValue)
+      : undefined;
+
+  const preferredCluster =
+    preferredClusterValue !== null &&
+    isRecommendationCluster(preferredClusterValue)
+      ? preferredClusterValue
+      : undefined;
+
+  return {
+    preferredBranchShopId,
+    preferredCluster,
+  };
+}
+
+function buildBranchOptions(
+  storesByShopId: Map<number, Store>
+): RecommendationBranchOption[] {
+  return Array.from(storesByShopId.values())
+    .map((store) => ({
+      shopId: store.shopId,
+      name: store.name,
+      cluster: store.recommendationCluster,
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name, 'zh-HK'));
+}
+
+function buildClusterOptions(
+  storesByShopId: Map<number, Store>
+): RecommendationCluster[] {
+  const clusterSet = new Set<RecommendationCluster>();
+
+  storesByShopId.forEach((store) => {
+    if (store.recommendationCluster !== RECOMMENDATION_CLUSTERS.UNKNOWN) {
+      clusterSet.add(store.recommendationCluster);
+    }
+  });
+
+  return Object.values(RECOMMENDATION_CLUSTERS).filter(
+    (cluster) =>
+      cluster !== RECOMMENDATION_CLUSTERS.UNKNOWN && clusterSet.has(cluster)
+  );
+}
+
+function getEligibleClusterCandidates(
+  data: QueueItem[],
+  storesByShopId: Map<number, Store>,
+  cluster: RecommendationCluster
+): QueueItem[] {
+  return data.filter(
+    (item) =>
+      isEligibleRecommendation(item) &&
+      storesByShopId.get(item.shopId)?.recommendationCluster === cluster
+  );
+}
+
+function createPreferenceMeta(
+  input: RecommendationPreferenceInput,
+  activeMode: RecommendationMode,
+  storesByShopId: Map<number, Store>,
+  overrides: Partial<
+    Pick<
+      RecommendationPreferenceMeta,
+      'activeBranchShopId' | 'activeCluster' | 'fallbackReasonCode'
+    >
+  > = {}
+): RecommendationPreferenceMeta {
+  return {
+    requestedBranchShopId: input.preferredBranchShopId,
+    requestedCluster: input.preferredCluster,
+    activeMode,
+    activeBranchShopId: overrides.activeBranchShopId,
+    activeCluster: overrides.activeCluster,
+    fallbackReasonCode: overrides.fallbackReasonCode,
+    branchOptions: buildBranchOptions(storesByShopId),
+    clusterOptions: buildClusterOptions(storesByShopId),
+  };
+}
+
+export function resolveRecommendationPreference(
+  input: RecommendationPreferenceInput,
+  data: QueueItem[],
+  storesByShopId: Map<number, Store>
+): RecommendationPreferenceMeta {
+  const preferredBranch =
+    input.preferredBranchShopId !== undefined
+      ? data.find((item) => item.shopId === input.preferredBranchShopId)
+      : undefined;
+  const preferredBranchStore =
+    input.preferredBranchShopId !== undefined
+      ? storesByShopId.get(input.preferredBranchShopId)
+      : undefined;
+  const preferredBranchEligible =
+    preferredBranch !== undefined &&
+    preferredBranchStore !== undefined &&
+    isEligibleRecommendation(preferredBranch);
+
+  if (preferredBranchEligible) {
+    return createPreferenceMeta(input, RECOMMENDATION_MODES.BRANCH, storesByShopId, {
+      activeBranchShopId: preferredBranch.shopId,
+      activeCluster:
+        preferredBranchStore.recommendationCluster !== RECOMMENDATION_CLUSTERS.UNKNOWN
+          ? preferredBranchStore.recommendationCluster
+          : undefined,
+    });
+  }
+
+  const branchFallbackReason: RecommendationFallbackReasonCode | undefined =
+    input.preferredBranchShopId === undefined
+      ? undefined
+      : preferredBranchStore === undefined
+        ? RECOMMENDATION_FALLBACK_REASON_CODES.PREFERRED_BRANCH_NOT_FOUND
+        : RECOMMENDATION_FALLBACK_REASON_CODES.PREFERRED_BRANCH_INELIGIBLE;
+
+  if (input.preferredCluster !== undefined) {
+    const eligibleClusterCandidates = getEligibleClusterCandidates(
+      data,
+      storesByShopId,
+      input.preferredCluster
+    );
+
+    if (eligibleClusterCandidates.length > 0) {
+      return createPreferenceMeta(
+        input,
+        RECOMMENDATION_MODES.CLUSTER,
+        storesByShopId,
+        {
+          activeCluster: input.preferredCluster,
+          fallbackReasonCode: branchFallbackReason,
+        }
+      );
+    }
+
+    return createPreferenceMeta(input, RECOMMENDATION_MODES.AUTO, storesByShopId, {
+      fallbackReasonCode:
+        branchFallbackReason ??
+        RECOMMENDATION_FALLBACK_REASON_CODES.PREFERRED_CLUSTER_UNAVAILABLE,
+    });
+  }
+
+  return createPreferenceMeta(input, RECOMMENDATION_MODES.AUTO, storesByShopId, {
+    fallbackReasonCode: branchFallbackReason,
+  });
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -168,6 +168,37 @@ export type QueueRecommendationState =
   | 'UNAVAILABLE'
   | 'INELIGIBLE';
 
+export const RECOMMENDATION_MODES = {
+  BRANCH: 'branch',
+  CLUSTER: 'cluster',
+  AUTO: 'auto',
+} as const;
+
+export type RecommendationMode =
+  (typeof RECOMMENDATION_MODES)[keyof typeof RECOMMENDATION_MODES];
+
+export const RECOMMENDATION_REASON_CODES = {
+  PREFERRED_BRANCH: 'PREFERRED_BRANCH',
+  SAME_CLUSTER_AS_PREFERRED_BRANCH: 'SAME_CLUSTER_AS_PREFERRED_BRANCH',
+  IN_SELECTED_CLUSTER: 'IN_SELECTED_CLUSTER',
+  NEARBY_FALLBACK: 'NEARBY_FALLBACK',
+  BEST_FALLBACK: 'BEST_FALLBACK',
+  OPEN_NOW: 'OPEN_NOW',
+  SHORT_WAIT: 'SHORT_WAIT',
+} as const;
+
+export type RecommendationReasonCode =
+  (typeof RECOMMENDATION_REASON_CODES)[keyof typeof RECOMMENDATION_REASON_CODES];
+
+export const RECOMMENDATION_FALLBACK_REASON_CODES = {
+  PREFERRED_BRANCH_NOT_FOUND: 'PREFERRED_BRANCH_NOT_FOUND',
+  PREFERRED_BRANCH_INELIGIBLE: 'PREFERRED_BRANCH_INELIGIBLE',
+  PREFERRED_CLUSTER_UNAVAILABLE: 'PREFERRED_CLUSTER_UNAVAILABLE',
+} as const;
+
+export type RecommendationFallbackReasonCode =
+  (typeof RECOMMENDATION_FALLBACK_REASON_CODES)[keyof typeof RECOMMENDATION_FALLBACK_REASON_CODES];
+
 export interface QueueItem {
   shopId: number;
   name: string;
@@ -175,6 +206,32 @@ export interface QueueItem {
   queueCount: number | null;
   level: QueueLevel;
   recommendationState: QueueRecommendationState;
+}
+
+export interface RecommendedQueueItem extends QueueItem {
+  reasonCodes: RecommendationReasonCode[];
+}
+
+export interface RecommendationPreferenceInput {
+  preferredBranchShopId?: number;
+  preferredCluster?: RecommendationCluster;
+}
+
+export interface RecommendationBranchOption {
+  shopId: number;
+  name: string;
+  cluster: RecommendationCluster;
+}
+
+export interface RecommendationPreferenceMeta {
+  requestedBranchShopId?: number;
+  requestedCluster?: RecommendationCluster;
+  activeMode: RecommendationMode;
+  activeBranchShopId?: number;
+  activeCluster?: RecommendationCluster;
+  fallbackReasonCode?: RecommendationFallbackReasonCode;
+  branchOptions: RecommendationBranchOption[];
+  clusterOptions: RecommendationCluster[];
 }
 
 export type QueueGroupKey = 'available' | 'low' | 'busy' | 'unavailable';
@@ -205,12 +262,13 @@ export interface QueueApiResponse {
   status: QueueSnapshotStatus;
   updatedAt: string;
   data: QueueItem[];
-  recommended: QueueItem[];
+  recommended: RecommendedQueueItem[];
   groups: QueueGroups;
   warnings: string[];
   partialData: boolean;
   errorCode?: string;
   meta: QueueSnapshotMeta;
+  preferences: RecommendationPreferenceMeta;
 }
 
 // Dashboard specific types

--- a/locales/en.json
+++ b/locales/en.json
@@ -17,7 +17,7 @@
     "open": "Open",
     "languages": {
       "en": "English",
-      "zh-HK": "繁體中文"
+      "zh-HK": "Traditional Chinese"
     },
     "regions": {
       "香港島": "Hong Kong Island",
@@ -41,13 +41,12 @@
       "北區": "North District",
       "大埔區": "Tai Po District",
       "沙田區": "Sha Tin District",
-      "西貢區": "Sai Kung District",
-      "離島區": "Islands District"
+      "西貢區": "Sai Kung District"
     }
   },
   "dashboard": {
     "title": "Store Queue Dashboard",
-    "subtitle": "Monitor store queues and wait times in real-time",
+    "subtitle": "Monitor store queues and wait times in real time",
     "stats": {
       "totalStores": "Total Stores",
       "totalWaiting": "Total Waiting",
@@ -98,7 +97,7 @@
     "general": "Something went wrong",
     "notFound": "Page not found",
     "networkError": "Network error occurred",
-    "failedToLoadData": "Failed to Load Data",
+    "failedToLoadData": "Failed to load data",
     "unableToFetchStores": "Unable to fetch store information from the server.",
     "unableToLoadData": "Unable to load data",
     "apiRequestFailed": "API request failed",
@@ -120,22 +119,22 @@
   },
   "dashboardQueue": {
     "title": "Sushiro Queue Dashboard",
-    "subtitle": "Scan all branches and spot the shortest queue first.",
+    "subtitle": "Set your preferred branch or area, then compare the best live queue options.",
     "availableNow": "Fastest Seating",
-    "availableNowHint": "Start with branches that can seat you immediately, then compare the shortest waits.",
+    "availableNowHint": "These branches can seat you right away, with nearby alternatives kept in view.",
     "bestOptions": "Best Options",
-    "bestOptionsHint": "Immediate seating is unavailable right now, so these are the shortest known waits.",
+    "bestOptionsHint": "Immediate seating is not available right now, so these are the strongest live queue options.",
     "moreAvailableHint": "+{count} more available below",
     "updatedAtLabel": "Updated",
     "refresh": "Refresh",
     "retry": "Retry",
     "loading": "Loading...",
     "empty": "No queue data is available right now.",
-    "noRecommendedStores": "All branches are currently closed or queue information is unavailable.",
+    "noRecommendedStores": "All branches are currently closed or live queue information is unavailable.",
     "error": "Unable to load queue data.",
     "partialDataTitle": "Queue data is partially available",
     "partialDataMessage": "Showing live queue results with {count} branches currently missing queue information.",
-    "recommendationsPartialHint": "Recommendations are based on the live queue data that is available right now.",
+    "recommendationsPartialHint": "Recommendations are based on the live queue data that is currently available.",
     "unavailableTitle": "Live queue data unavailable",
     "unavailableHint": "Store metadata or queue data could not be loaded right now. Try refreshing again shortly.",
     "refreshing": "Refreshing",
@@ -159,7 +158,8 @@
       "subtitle": "Pick a branch or area and we will anchor the recommendation there before widening out.",
       "branchLabel": "Preferred branch",
       "clusterLabel": "Preferred area",
-      "autoOption": "Auto",
+      "autoOption": "Best available",
+      "branchPriorityHint": "A preferred branch takes priority. Changing the area clears the branch preference.",
       "activeMode": {
         "branch": "Using your preferred branch: {name}",
         "cluster": "Using your selected area: {cluster}",
@@ -167,7 +167,7 @@
       },
       "fallbackMessages": {
         "PREFERRED_BRANCH_NOT_FOUND": "The selected branch is no longer available, so we widened the scope.",
-        "PREFERRED_BRANCH_INELIGIBLE": "The selected branch is not recommendable right now, so we widened the scope.",
+        "PREFERRED_BRANCH_INELIGIBLE": "The selected branch is not recommendable right now, so nearby alternatives are shown instead.",
         "PREFERRED_CLUSTER_UNAVAILABLE": "The selected area has no recommendable branches right now, so we widened the scope."
       },
       "reasonLabels": {
@@ -185,7 +185,7 @@
         "WEST_KOWLOON": "West Kowloon",
         "EAST_KOWLOON": "East Kowloon",
         "TSEUNG_KWAN_O": "Tseung Kwan O",
-        "SHA_TIN_BELT": "Sha Tin belt",
+        "SHA_TIN_BELT": "Sha Tin Belt",
         "NORTH_NT": "North New Territories",
         "TSUEN_KWAN_WEST": "Tsuen Wan / Kwai Tsing",
         "FAR_WEST_NT": "Tuen Mun / Yuen Long",

--- a/locales/en.json
+++ b/locales/en.json
@@ -153,6 +153,44 @@
     "busyStatus": "Busy",
     "queueUnavailableStatus": "Queue unavailable",
     "invalid": "Unavailable",
-    "emptyGroup": "No branches in this group."
+    "emptyGroup": "No branches in this group.",
+    "preference": {
+      "title": "Recommendation preference",
+      "subtitle": "Pick a branch or area and we will anchor the recommendation there before widening out.",
+      "branchLabel": "Preferred branch",
+      "clusterLabel": "Preferred area",
+      "autoOption": "Auto",
+      "activeMode": {
+        "branch": "Using your preferred branch: {name}",
+        "cluster": "Using your selected area: {cluster}",
+        "auto": "Using automatic recommendations"
+      },
+      "fallbackMessages": {
+        "PREFERRED_BRANCH_NOT_FOUND": "The selected branch is no longer available, so we widened the scope.",
+        "PREFERRED_BRANCH_INELIGIBLE": "The selected branch is not recommendable right now, so we widened the scope.",
+        "PREFERRED_CLUSTER_UNAVAILABLE": "The selected area has no recommendable branches right now, so we widened the scope."
+      },
+      "reasonLabels": {
+        "PREFERRED_BRANCH": "your preferred branch",
+        "SAME_CLUSTER_AS_PREFERRED_BRANCH": "same area as your preferred branch",
+        "IN_SELECTED_CLUSTER": "in your selected area",
+        "NEARBY_FALLBACK": "nearby fallback",
+        "BEST_FALLBACK": "best fallback",
+        "OPEN_NOW": "open now",
+        "SHORT_WAIT": "short wait"
+      },
+      "clusterLabels": {
+        "HK_ISLAND_WEST": "Hong Kong Island West",
+        "HK_ISLAND_EAST": "Hong Kong Island East",
+        "WEST_KOWLOON": "West Kowloon",
+        "EAST_KOWLOON": "East Kowloon",
+        "TSEUNG_KWAN_O": "Tseung Kwan O",
+        "SHA_TIN_BELT": "Sha Tin belt",
+        "NORTH_NT": "North New Territories",
+        "TSUEN_KWAN_WEST": "Tsuen Wan / Kwai Tsing",
+        "FAR_WEST_NT": "Tuen Mun / Yuen Long",
+        "UNKNOWN": "Unknown"
+      }
+    }
   }
 }

--- a/locales/zh-HK.json
+++ b/locales/zh-HK.json
@@ -153,6 +153,44 @@
     "busyStatus": "繁忙",
     "queueUnavailableStatus": "排隊資料未齊",
     "invalid": "未能提供",
-    "emptyGroup": "呢個分組暫時冇分店。"
+    "emptyGroup": "呢個分組暫時冇分店。",
+    "preference": {
+      "title": "推薦偏好",
+      "subtitle": "揀一間分店或者一個區域，我哋會先喺嗰個範圍幫你排推薦，再慢慢向外 fallback。",
+      "branchLabel": "偏好分店",
+      "clusterLabel": "偏好區域",
+      "autoOption": "自動",
+      "activeMode": {
+        "branch": "而家跟你揀嘅分店：{name}",
+        "cluster": "而家跟你揀嘅區域：{cluster}",
+        "auto": "而家用自動推薦"
+      },
+      "fallbackMessages": {
+        "PREFERRED_BRANCH_NOT_FOUND": "你揀嗰間分店而家冇喺結果入面，所以已經自動擴大範圍。",
+        "PREFERRED_BRANCH_INELIGIBLE": "你揀嗰間分店而家唔適合推薦，所以已經自動擴大範圍。",
+        "PREFERRED_CLUSTER_UNAVAILABLE": "你揀嗰個區域而家冇可推薦分店，所以已經自動擴大範圍。"
+      },
+      "reasonLabels": {
+        "PREFERRED_BRANCH": "你揀嘅分店",
+        "SAME_CLUSTER_AS_PREFERRED_BRANCH": "同你偏好分店同區",
+        "IN_SELECTED_CLUSTER": "喺你揀嘅區域",
+        "NEARBY_FALLBACK": "附近 fallback",
+        "BEST_FALLBACK": "最佳 fallback",
+        "OPEN_NOW": "而家有位",
+        "SHORT_WAIT": "輪候較短"
+      },
+      "clusterLabels": {
+        "HK_ISLAND_WEST": "港島西",
+        "HK_ISLAND_EAST": "港島東",
+        "WEST_KOWLOON": "西九龍",
+        "EAST_KOWLOON": "東九龍",
+        "TSEUNG_KWAN_O": "將軍澳",
+        "SHA_TIN_BELT": "沙田帶",
+        "NORTH_NT": "新界北",
+        "TSUEN_KWAN_WEST": "荃灣／葵青",
+        "FAR_WEST_NT": "屯門／元朗",
+        "UNKNOWN": "未知"
+      }
+    }
   }
 }

--- a/locales/zh-HK.json
+++ b/locales/zh-HK.json
@@ -2,7 +2,7 @@
   "common": {
     "loading": "載入中...",
     "error": "錯誤",
-    "retry": "再試一次",
+    "retry": "重試",
     "close": "關閉",
     "save": "儲存",
     "cancel": "取消",
@@ -13,8 +13,8 @@
     "refreshing": "更新中...",
     "refreshStarted": "開始更新資料...",
     "refreshComplete": "資料已成功更新",
-    "last": "最後更新",
-    "open": "營業中",
+    "last": "最後更新時間",
+    "open": "開啟",
     "languages": {
       "en": "English",
       "zh-HK": "繁體中文"
@@ -41,39 +41,38 @@
       "北區": "北區",
       "大埔區": "大埔區",
       "沙田區": "沙田區",
-      "西貢區": "西貢區",
-      "離島區": "離島區"
+      "西貢區": "西貢區"
     }
   },
   "dashboard": {
-    "title": "分店排隊儀表板",
-    "subtitle": "即時查看各分店排隊及輪候狀況",
+    "title": "分店輪候 Dashboard",
+    "subtitle": "即時睇分店輪候情況同等候壓力",
     "stats": {
       "totalStores": "分店總數",
       "totalWaiting": "輪候總數",
-      "currentQueue": "目前隊列",
+      "currentQueue": "目前輪候",
       "filteredResults": "篩選結果",
       "openStores": "營業中",
-      "acrossAllStores": "所有分店合計",
+      "acrossAllStores": "所有分店",
       "activeTickets": "有效票號",
       "showing": "顯示中"
     },
     "filters": {
-      "searchPlaceholder": "按分店名、地區或區域搜尋...",
-      "allRegions": "所有地區",
-      "allWaitTimes": "所有輪候時間",
-      "lowWait": "短輪候",
-      "mediumWait": "中輪候",
-      "highWait": "長輪候",
-      "extremeWait": "極長輪候"
+      "searchPlaceholder": "按分店、地區或分區搜尋...",
+      "allRegions": "全部地區",
+      "allWaitTimes": "全部等候時間",
+      "lowWait": "較短等候",
+      "mediumWait": "中等等候",
+      "highWait": "較長等候",
+      "extremeWait": "極長等候"
     },
     "viewMode": {
       "grid": "網格",
       "showingStores": "顯示 {count} 間分店",
-      "inViewMode": "以 {mode} 檢視"
+      "inViewMode": "{mode} 檢視"
     },
     "noResults": {
-      "title": "找不到分店",
+      "title": "搵唔到分店",
       "message": "試下調整搜尋或篩選條件"
     }
   },
@@ -83,23 +82,23 @@
       "closed": "已關閉",
       "disconnected": "未連線"
     },
-    "waiting": "輪候",
+    "waiting": "輪候中",
     "current": "目前",
-    "queue": "隊列",
-    "currentQueue": "目前隊列",
-    "moreTickets": "另有 {count} 張票",
-    "noTickets": "沒有票號"
+    "queue": "輪候",
+    "currentQueue": "目前輪候",
+    "moreTickets": "仲有 +{count}",
+    "noTickets": "冇票號"
   },
   "navigation": {
     "home": "首頁",
-    "dashboard": "儀表板"
+    "dashboard": "Dashboard"
   },
   "errors": {
     "general": "發生錯誤",
-    "notFound": "找不到頁面",
+    "notFound": "搵唔到頁面",
     "networkError": "網絡錯誤",
     "failedToLoadData": "載入資料失敗",
-    "unableToFetchStores": "未能從伺服器取得分店資料。",
+    "unableToFetchStores": "暫時未能從伺服器取得分店資料。",
     "unableToLoadData": "未能載入資料",
     "apiRequestFailed": "API 請求失敗",
     "unknownError": "發生未知錯誤"
@@ -108,76 +107,77 @@
     "grid": "網格",
     "table": "表格",
     "switchToView": "切換到 {view} 檢視",
-    "viewModeSelector": "檢視模式選擇"
+    "viewModeSelector": "檢視模式選擇器"
   },
   "table": {
     "store": "分店",
     "region": "地區",
-    "district": "區域",
+    "district": "分區",
     "status": "狀態",
     "columns": "欄位",
     "toggleColumns": "切換欄位"
   },
   "dashboardQueue": {
-    "title": "壽司郎排隊睇板",
-    "subtitle": "一次過睇晒各分店排隊情況，快手搵到較短嘅隊。",
-    "availableNow": "即刻可入座",
-    "availableNowHint": "先睇而家可以即刻入座嘅分店，再比較其餘較短輪候時間。",
-    "bestOptions": "較佳選擇",
-    "bestOptionsHint": "而家未有即刻可入座分店，以下係目前已知輪候時間較短嘅選擇。",
-    "moreAvailableHint": "下面仲有 {count} 間即刻可入座",
+    "title": "Sushiro 輪候 Dashboard",
+    "subtitle": "先揀心水分店或者心水區域，再比較而家最值得去嘅 live queue 選擇。",
+    "availableNow": "最快可入座",
+    "availableNowHint": "以下分店而家可以即刻入座，同時都保留附近替代選擇畀你比較。",
+    "bestOptions": "最佳選擇",
+    "bestOptionsHint": "而家未有即時入座選項，所以以下係目前 live queue 最有機會嘅選擇。",
+    "moreAvailableHint": "下面仲有 +{count} 間可即時入座",
     "updatedAtLabel": "更新時間",
     "refresh": "重新整理",
-    "retry": "再試一次",
+    "retry": "重試",
     "loading": "載入中...",
-    "empty": "而家暫時未有可用排隊資料。",
-    "noRecommendedStores": "而家所有分店不是休業中，就是暫時未能提供排隊資料。",
-    "error": "未能載入排隊資料。",
-    "partialDataTitle": "排隊資料部分可用",
-    "partialDataMessage": "而家仍然會顯示 live queue 結果，但有 {count} 間分店暫時未拎到排隊資料。",
-    "recommendationsPartialHint": "目前推薦只根據而家拎到嘅 live queue data 計算。",
-    "unavailableTitle": "暫時無法載入 live queue 資料",
-    "unavailableHint": "而家未能載入分店資料或者排隊資料，過一陣再 refresh 試下。",
+    "empty": "而家未有 queue data。",
+    "noRecommendedStores": "而家全部分店都未能推薦，可能已休息或者暫時冇 live queue 資料。",
+    "error": "未能載入 queue data。",
+    "partialDataTitle": "Queue data 只有部分可用",
+    "partialDataMessage": "而家照樣顯示 live queue 結果，但有 {count} 間分店暫時未有 queue 資料。",
+    "recommendationsPartialHint": "以下推薦係根據目前攞到嘅 live queue data 產生。",
+    "unavailableTitle": "暫時未能載入 live queue data",
+    "unavailableHint": "而家未能載入分店 metadata 或 queue data，請稍後再試。",
     "refreshing": "更新中",
-    "retryHint": "試下重新整理，載入最新排隊畫面。",
-    "liveMonitor": "即時排隊監察",
+    "retryHint": "重新整理以載入最新 queue 情況。",
+    "liveMonitor": "Live Queue Monitor",
     "availableGroup": "可即時入座",
-    "lowGroup": "較短輪候",
+    "lowGroup": "較短等候",
     "busyGroup": "繁忙",
     "otherGroup": "其他",
-    "unavailableGroup": "資料未齊",
-    "availableNowStatus": "即刻可入座",
-    "closedStatus": "休業中",
+    "unavailableGroup": "未能提供",
+    "availableNowStatus": "可即時入座",
+    "closedStatus": "已關閉",
     "maintenanceStatus": "維護中",
-    "lowStatus": "較短輪候",
-    "busyStatus": "繁忙",
-    "queueUnavailableStatus": "排隊資料未齊",
+    "lowStatus": "等候較短",
+    "busyStatus": "較繁忙",
+    "queueUnavailableStatus": "未有 queue 資料",
     "invalid": "未能提供",
-    "emptyGroup": "呢個分組暫時冇分店。",
+    "emptyGroup": "呢組暫時冇分店。",
     "preference": {
       "title": "推薦偏好",
-      "subtitle": "揀一間分店或者一個區域，我哋會先喺嗰個範圍幫你排推薦，再慢慢向外 fallback。",
-      "branchLabel": "偏好分店",
-      "clusterLabel": "偏好區域",
-      "autoOption": "自動",
+      "subtitle": "你可以揀心水分店或者心水區域，系統會先跟呢個偏好，再逐步向外擴闊推薦。",
+      "branchLabel": "心水分店",
+      "clusterLabel": "心水區域",
+      "autoOption": "最佳可選",
+      "branchPriorityHint": "如果有心水分店，系統會優先跟分店；改區域會清除分店偏好。",
       "activeMode": {
-        "branch": "而家跟你揀嘅分店：{name}",
-        "cluster": "而家跟你揀嘅區域：{cluster}",
-        "auto": "而家用自動推薦"
+        "branch": "而家以你嘅心水分店為主：{name}",
+        "cluster": "而家以你揀嘅區域為主：{cluster}",
+        "auto": "而家顯示全局最佳可選"
       },
       "fallbackMessages": {
-        "PREFERRED_BRANCH_NOT_FOUND": "你揀嗰間分店而家冇喺結果入面，所以已經自動擴大範圍。",
-        "PREFERRED_BRANCH_INELIGIBLE": "你揀嗰間分店而家唔適合推薦，所以已經自動擴大範圍。",
-        "PREFERRED_CLUSTER_UNAVAILABLE": "你揀嗰個區域而家冇可推薦分店，所以已經自動擴大範圍。"
+        "PREFERRED_BRANCH_NOT_FOUND": "搵唔到你揀嘅心水分店，所以系統改用下一層偏好去推薦。",
+        "PREFERRED_BRANCH_INELIGIBLE": "你揀嘅心水分店而家唔適合推薦，所以先顯示附近替代選擇。",
+        "PREFERRED_CLUSTER_UNAVAILABLE": "你揀嘅區域而家冇可推薦分店，所以 dashboard 先退回全局最佳可選。"
       },
       "reasonLabels": {
-        "PREFERRED_BRANCH": "你揀嘅分店",
-        "SAME_CLUSTER_AS_PREFERRED_BRANCH": "同你偏好分店同區",
-        "IN_SELECTED_CLUSTER": "喺你揀嘅區域",
-        "NEARBY_FALLBACK": "附近 fallback",
+        "PREFERRED_BRANCH": "你揀咗呢間",
+        "SAME_CLUSTER_AS_PREFERRED_BRANCH": "同你心水分店同區",
+        "IN_SELECTED_CLUSTER": "屬於你揀嘅區域",
+        "NEARBY_FALLBACK": "附近替代選擇",
         "BEST_FALLBACK": "最佳 fallback",
-        "OPEN_NOW": "而家有位",
-        "SHORT_WAIT": "輪候較短"
+        "OPEN_NOW": "而家可入座",
+        "SHORT_WAIT": "等候較短"
       },
       "clusterLabels": {
         "HK_ISLAND_WEST": "港島西",
@@ -187,8 +187,8 @@
         "TSEUNG_KWAN_O": "將軍澳",
         "SHA_TIN_BELT": "沙田帶",
         "NORTH_NT": "新界北",
-        "TSUEN_KWAN_WEST": "荃灣／葵青",
-        "FAR_WEST_NT": "屯門／元朗",
+        "TSUEN_KWAN_WEST": "荃灣 / 葵青",
+        "FAR_WEST_NT": "屯門 / 元朗",
         "UNKNOWN": "未知"
       }
     }


### PR DESCRIPTION
## Summary
- add preferred branch and preferred area selectors to the queue dashboard
- wire `/api/queues` preference handling through backend-owned active mode resolution and reason-coded recommendations
- polish English and zh-HK queue copy for preference summaries, fallback messaging, and reason labels

## Verification
- `npm.cmd run type-check`
- `vitest` could not be executed in this workspace because the executable is missing from `node_modules`
